### PR TITLE
Adding extension storage services for portfolio plans

### DIFF
--- a/src/Common/GUIDUtil.ts
+++ b/src/Common/GUIDUtil.ts
@@ -1,0 +1,32 @@
+export class GUIDUtil {
+    /**
+     * Returns a GUID such as xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx.
+     * @return New GUID.(UUID version 4 = xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
+     * @notes Disclaimer: This implementation uses non-cryptographic random number generator so absolute uniqueness is not guaranteed.
+     */
+    public static newGuid(): string {
+        // c.f. rfc4122 (UUID version 4 = xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
+        // "Set the two most significant bits (bits 6 and 7) of the clock_seq_hi_and_reserved to zero and one, respectively"
+        var clockSequenceHi = (128 + Math.floor(Math.random() * 64)).toString(16);
+        return GUIDUtil.oct(8) + "-" + GUIDUtil.oct(4) + "-4" + GUIDUtil.oct(3) + "-" + clockSequenceHi + GUIDUtil.oct(2) + "-" + GUIDUtil.oct(12);
+    }
+
+    /**
+     * Generated non-zero octet sequences for use with GUID generation.
+     *
+     * @param length Length required.
+     * @return Non-Zero hex sequences.
+     */
+    private static oct(length?: number): string {
+        if (!length) {
+            return (Math.floor(Math.random() * 0x10)).toString(16);
+        }
+
+        var result: string = "";
+        for (var i: number = 0; i < length; i++) {
+            result += GUIDUtil.oct();
+        }
+
+        return result;
+    }
+}

--- a/src/Common/OData/ODataClient.ts
+++ b/src/Common/OData/ODataClient.ts
@@ -1,4 +1,5 @@
 import { authTokenManager } from "VSS/Authentication/Services";
+import { GUIDUtil } from "../GUIDUtil";
 /// <reference types='jquery' />
 /// <reference types='jqueryui' />
 
@@ -121,7 +122,6 @@ export class ODataClient {
         return $.ajax(contentRequest);
     }
 
-   
     /**
      * Generates an OData Payload, acccording to OData POST/Batch contract. Note, this only supplies a single request
      * @param getUrl The long-form URL for the request
@@ -143,37 +143,4 @@ export class ODataClient {
         return $.ajax(this.constructXmlRequest(this.authToken, "GET", this.generateProjectLink(projectName, entityName)));
     }
 
-}
-
-class GUIDUtil {
-    /**
-     * Returns a GUID such as xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx.
-     * @return New GUID.(UUID version 4 = xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
-     * @notes Disclaimer: This implementation uses non-cryptographic random number generator so absolute uniqueness is not guaranteed.
-     */
-    public static newGuid(): string {
-        // c.f. rfc4122 (UUID version 4 = xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
-        // "Set the two most significant bits (bits 6 and 7) of the clock_seq_hi_and_reserved to zero and one, respectively"
-        var clockSequenceHi = (128 + Math.floor(Math.random() * 64)).toString(16);
-        return GUIDUtil.oct(8) + "-" + GUIDUtil.oct(4) + "-4" + GUIDUtil.oct(3) + "-" + clockSequenceHi + GUIDUtil.oct(2) + "-" + GUIDUtil.oct(12);
-    }
-
-    /**
-     * Generated non-zero octet sequences for use with GUID generation.
-     *
-     * @param length Length required.
-     * @return Non-Zero hex sequences.
-     */
-    private static oct(length?: number): string {
-        if (!length) {
-            return (Math.floor(Math.random() * 0x10)).toString(16);
-        }
-
-        var result: string = "";
-        for (var i: number = 0; i < length; i++) {
-            result += GUIDUtil.oct();
-        }
-
-        return result;
-    }
 }

--- a/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
+++ b/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
@@ -77,4 +77,41 @@ export interface WorkItem
 export interface IQueryResultError
 {
     exceptionMessage: string;
+    status?: number;
+}
+
+
+export interface PortfolioPlanningMetadata
+{
+    id: string;
+    name: string;
+    createdOn: Date;
+}
+
+export interface PortfolioPlanning extends PortfolioPlanningMetadata
+{
+    projects: ProjectPortfolioPlanning[]
+}
+
+export interface ProjectPortfolioPlanning
+{
+    ProjectId: string;
+    PortfolioWorkItemType: string;
+    RequirementWorkItemType: string;
+    WorkItemIds: number[];
+}
+
+export interface PortfolioPlanningDirectory extends IQueryResultError
+{
+    id: string;
+    entries: PortfolioPlanningMetadata[]
+}
+
+export interface ExtensionStorageError 
+{
+    stack: string;
+    message: string;
+    name: string;
+    status: number;
+    responseText: string;
 }

--- a/src/PortfolioPlanning/Redux/Sagas/LoadPortfolio.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/LoadPortfolio.ts
@@ -4,7 +4,9 @@ import {
 } from "../../../Services/PortfolioPlanningDataService";
 import { 
     PortfolioPlanningQueryInput, 
-    PortfolioPlanningProjectQueryInput 
+    PortfolioPlanningProjectQueryInput, 
+    PortfolioPlanningDirectory,
+    PortfolioPlanning
 } from "../../Models/PortfolioPlanningQueryModels";
 import { 
     EpicTimelineActions 
@@ -14,31 +16,40 @@ export function* LoadPortfolio() {
 
     //  TODO    User Story 1559920: Load epics and project information from extension storage
     //  These values are only for testing wiring of OData service to UI.
-    const workItemId = 5250;
-    const projectId = "FBED1309-56DB-44DB-9006-24AD73EEE785";
+    //const workItemId = 5250;
+    //const projectId = "FBED1309-56DB-44DB-9006-24AD73EEE785";
 
-    const service = PortfolioPlanningDataService.getInstance();
+    const portfolioService = PortfolioPlanningDataService.getInstance();
+
+    const allPlans:PortfolioPlanningDirectory = yield call([portfolioService, portfolioService.GetAllPortfolioPlans]);
+    
+    const planId = allPlans.entries[0].id;
+    const planInfo:PortfolioPlanning = yield call([portfolioService, portfolioService.GetPortfolioPlanById], planId);
+
     const portfolioQueryInput: PortfolioPlanningQueryInput = {
-        //  TODO    Update with values from backlog configuration
-        PortfolioWorkItemType: "Epic",
-        //  TODO    Update with values from backlog configuration
-        RequirementWorkItemTypes: ["User Story"],
-        WorkItems: [
-            {
-                projectId: projectId,
-                workItemIds: [workItemId]
-            }
-        ]
+        //  TODO    Only supporting one work item type per plan for now. Work item type should be per project.
+        PortfolioWorkItemType: planInfo.projects[0].PortfolioWorkItemType,
+
+        //  TODO    Only supporting one work item type per plan for now. Work item type should be per project.
+        RequirementWorkItemTypes: [planInfo.projects[0].RequirementWorkItemType],
+
+        WorkItems: planInfo.projects.map((projectInfo) => 
+        {
+            return {
+                projectId: projectInfo.ProjectId,
+                workItemIds: projectInfo.WorkItemIds
+            };
+        })
     };
 
     const projectsQueryInput: PortfolioPlanningProjectQueryInput = {
-        projectIds: [projectId]
+        projectIds: planInfo.projects.map((projectInfo) => projectInfo.ProjectId)
     };
 
     const [portfolioQueryResult, projectQueryResult] = yield all(
         [
-            call([service, service.runPortfolioItemsQuery], portfolioQueryInput),
-            call([service, service.runProjectQuery], projectsQueryInput)
+            call([portfolioService, portfolioService.runPortfolioItemsQuery], portfolioQueryInput),
+            call([portfolioService, portfolioService.runProjectQuery], projectsQueryInput)
         ]);
 
     yield put(EpicTimelineActions.portfolioItemsReceived(portfolioQueryResult, projectQueryResult));


### PR DESCRIPTION
Creates two collections in the extension storage: 
- Directory: stores all portfolio plans in the account, with a single document entry that list all plans.
- PortfolioPlans: stores a document entry per portfolio plan that includes the project ids and work items ids in the plan.