### PR TITLE
Navigate to epic road map from portfolio planning

### DIFF
--- a/src/EpicRoadmap/redux/sagas/FetchAllMetadata.ts
+++ b/src/EpicRoadmap/redux/sagas/FetchAllMetadata.ts
@@ -10,9 +10,14 @@ import { BacklogConfiguration } from "TFS/Work/Contracts";
 import { WorkItemMetadataService } from "../../../Services/WorkItemMetadataService";
 import { workItemTypesReceived, workItemStateColorsReceived } from "../modules/workItemMetadata/workItemMetadataActionCreators";
 import { EpicsMetadataAvailable } from "../contracts";
+import { selectEpic } from "../../../Common/redux/modules/SettingsState/SettingsStateActions";
 
 export function* FetchAllMetadata() {
     yield put(ProgressAwareActionCreator.setLoading(true));
+
+    const navigationService : IHostNavigationService = yield call([VSS, VSS.getService], VSS.ServiceIds.Navigation);
+    const selectedWorkItemIdInUrl = yield call([navigationService, navigationService.getHash]);
+
     const projectId = getProjectId();
     const teamId = getTeamId();
     // get backlog configuration/ team settings and backlog iteration for the project/current team
@@ -42,4 +47,9 @@ export function* FetchAllMetadata() {
     yield put(workItemTypesReceived(projectId, wits));
     yield put(workItemStateColorsReceived(projectId, stateColors));
     yield put({ type: EpicsMetadataAvailable });
+
+    if(selectedWorkItemIdInUrl)
+    {
+        yield put(selectEpic(selectedWorkItemIdInUrl));
+    }
 }

--- a/src/PortfolioPlanning/Components/EpicTimeline.tsx
+++ b/src/PortfolioPlanning/Components/EpicTimeline.tsx
@@ -70,6 +70,10 @@ export class EpicTimeline extends React.Component<
             this.props.items
         );
 
+        const forwardCircleStyle ={
+            padding: '0px 0px 0px 10px',
+        };
+
         return (
             <div>
                 <div className="configuration-container">
@@ -166,6 +170,12 @@ export class EpicTimeline extends React.Component<
                                             total={item.itemProps.total}
                                             onClick={() => {}}
                                         />
+                                        <div
+                                            className="bowtie-icon bowtie-navigate-forward-circle"
+                                            style={forwardCircleStyle}
+                                            onClick={() => this.navigateToEpicRoadmap(item)}>
+                                            &nbsp;
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -291,6 +301,23 @@ export class EpicTimeline extends React.Component<
         }
 
         return [startTime, endTime];
+    }
+
+    private navigateToEpicRoadmap(item: ITimelineItem)
+    {
+        const collectionUri = VSS.getWebContext().collection.uri;
+        const projectName = item.group;
+        const teamId = item.teamId;
+        //  TODO    Need to get the backlog level somewhere....
+        const backlogLevel = "Epics";
+        const workItemId = item.id;
+
+        const targerUrl = `${collectionUri}${projectName}/_backlogs/ms-devlabs.workitem-feature-timeline-extension-dev.workitem-epic-roadmap/${teamId}/${backlogLevel}#${workItemId}`;
+
+        VSS.getService<IHostNavigationService>(VSS.ServiceIds.Navigation).then(
+            (client) => client.navigate(targerUrl),
+            (error) => alert(error)
+        );
     }
 }
 

--- a/src/PortfolioPlanning/Contracts.ts
+++ b/src/PortfolioPlanning/Contracts.ts
@@ -8,6 +8,7 @@ export interface IProject {
 export interface IEpic {
     id: number;
     project: string;
+    teamId: string;
     title: string;
     startDate?: Date;
     endDate?: Date;
@@ -30,6 +31,7 @@ export interface ITimelineGroup {
 export interface ITimelineItem {
     id: number;
     group: string;
+    teamId: string;
     title: string;
     start_time: moment.Moment;
     end_time: moment.Moment;

--- a/src/PortfolioPlanning/Models/ODataQueryModels.ts
+++ b/src/PortfolioPlanning/Models/ODataQueryModels.ts
@@ -7,6 +7,7 @@ export interface ODataWorkItemQueryResult
     StartDate: Date;
     TargetDate: Date;
     ProjectSK: string;
+    AreaSK: string;
     Descendants: ODataWorkItemDescendants[]
 }
 
@@ -24,4 +25,17 @@ export interface ODataQueryProjectInput
 {
     projectId: string;
     workItemIds: number[];
+}
+
+export interface ODataAreaQueryResult
+{
+    ProjectSK: string;
+    AreaSK: string;
+    Teams : ODataTeamResult[];
+}
+
+export interface ODataTeamResult
+{
+    TeamSK: string;
+    TeamName: string;
 }

--- a/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
+++ b/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
@@ -34,6 +34,8 @@ export interface PortfolioPlanningQueryResultItem
     TargetDate: Date;
 
     ProjectId: string;
+    AreaId: string;
+    TeamId: string;
 
     CompletedCount: number;
     TotalCount: number;
@@ -115,3 +117,29 @@ export interface ExtensionStorageError
     status: number;
     responseText: string;
 }
+
+
+export interface PortfolioPlanningTeamsInAreaQueryInput
+{
+    /**
+     * AreaIds by project id.
+     */
+    [projectId: string] : string[];
+}
+
+export interface PortfolioPlanningTeamsInAreaQueryResult extends IQueryResultError
+{
+    teamsInArea: TeamsInArea;
+}
+
+export interface TeamsInArea
+{
+    [areaId: string] : Team[]
+}
+
+export interface Team
+{
+    teamId: string;
+    teamName: string;
+}
+

--- a/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
+++ b/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
@@ -6,7 +6,8 @@ import { IEpic, ProgressTrackingCriteria } from "../../Contracts";
 import moment = require("moment");
 import {
     PortfolioPlanningQueryResult,
-    PortfolioPlanningProjectQueryResult
+    PortfolioPlanningProjectQueryResult,
+    PortfolioPlanningTeamsInAreaQueryResult
 } from "../../Models/PortfolioPlanningQueryModels";
 import { Action } from "redux";
 
@@ -46,12 +47,16 @@ export const EpicTimelineActions = {
         createAction(EpicTimelineActionTypes.SetSelectedItemId, { id }),
     portfolioItemsReceived: (
         portfolioQueryResult: PortfolioPlanningQueryResult,
-        projectsQueryResult: PortfolioPlanningProjectQueryResult
+        projectsQueryResult: PortfolioPlanningProjectQueryResult,
+        teamAreasQueryResult: PortfolioPlanningTeamsInAreaQueryResult
     ) =>
-        createAction(EpicTimelineActionTypes.PortfolioItemsReceived, {
-            portfolioQueryResult,
-            projectsQueryResult
-        }),
+        {
+            return createAction(EpicTimelineActionTypes.PortfolioItemsReceived, {
+                portfolioQueryResult,
+                projectsQueryResult,
+                teamAreasQueryResult
+            });
+        },
     openAddEpicDialog: () =>
         createAction(EpicTimelineActionTypes.OpenAddEpicDialog),
     closeAddEpicDialog: () =>
@@ -73,5 +78,6 @@ export interface PortfolioItemsReceivedAction extends Action {
     payload: {
         portfolioQueryResult: PortfolioPlanningQueryResult;
         projectsQueryResult: PortfolioPlanningProjectQueryResult;
+        teamAreasQueryResult: PortfolioPlanningTeamsInAreaQueryResult;
     };
 }

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -148,10 +148,14 @@ export function getDefaultState(): IEpicTimelineState {
 
 function handlePortfolioItemsReceived(
     state: IEpicTimelineState,
-    action: PortfolioItemsReceivedAction
+    action: PortfolioItemsReceivedAction,
 ): IEpicTimelineState {
     return produce(state, draft => {
-        const { portfolioQueryResult, projectsQueryResult } = action.payload;
+        const { 
+            portfolioQueryResult, 
+            projectsQueryResult,
+            teamAreasQueryResult
+         } = action.payload;
 
         //  TODO    Handle exception message from OData query results.
 
@@ -162,20 +166,27 @@ function handlePortfolioItemsReceived(
             };
         });
 
-        draft.epics = portfolioQueryResult.items.map(item => {
-            return {
-                id: item.WorkItemId,
-                project: item.ProjectId,
-                title: item.Title,
-                startDate: item.StartDate,
-                endDate: item.TargetDate,
-                completedCount: item.CompletedCount,
-                totalCount: item.TotalCount,
-                completedStoryPoints: item.CompletedStoryPoints,
-                totalStoryPoints: item.TotalStoryPoints,
-                storyPointsProgress: item.StoryPointsProgress,
-                countProgress: item.CountProgress
-            };
+        draft.epics = portfolioQueryResult.items.map(
+            item => {
+                //  Using the first team found for the area, if available.
+                const teamIdValue: string = (teamAreasQueryResult.teamsInArea[item.AreaId] && teamAreasQueryResult.teamsInArea[item.AreaId][0]) ?
+                    teamAreasQueryResult.teamsInArea[item.AreaId][0].teamId :
+                    null;
+
+                return {
+                    id: item.WorkItemId,
+                    project: item.ProjectId,
+                    teamId: teamIdValue,
+                    title: item.Title,
+                    startDate: item.StartDate,
+                    endDate: item.TargetDate,
+                    completedCount: item.CompletedCount,
+                    totalCount: item.TotalCount,
+                    completedStoryPoints: item.CompletedStoryPoints,
+                    totalStoryPoints: item.TotalStoryPoints,
+                    storyPointsProgress: item.StoryPointsProgress,
+                    countProgress: item.CountProgress
+                };
         });
     });
 }

--- a/src/PortfolioPlanning/Redux/SampleData.ts
+++ b/src/PortfolioPlanning/Redux/SampleData.ts
@@ -7,6 +7,7 @@ const secondProjectName = "Project 2";
 const thirdProjectId = "3";
 const thirdProjectName = "Project 3";
 const fourthProjectId = "4";
+const teamId = "fbed1309-56db-44db-9006-24ad73eee785";
 
 export const Projects: IProject[] = [
     { id: firstProjectId, title: firstProjectName },
@@ -18,6 +19,7 @@ export const Epics: IEpic[] = [
     {
         id: 1,
         project: firstProjectId,
+        teamId: teamId,
         title: "Epic 1",
         startDate: new Date(2019, 5, 1),
         endDate: new Date(2019, 6, 1),
@@ -31,6 +33,7 @@ export const Epics: IEpic[] = [
     {
         id: 2,
         project: firstProjectId,
+        teamId: teamId,
         title: "Epic 2",
         startDate: new Date(2019, 4, 1),
         endDate: new Date(2019, 7, 15),
@@ -44,6 +47,7 @@ export const Epics: IEpic[] = [
     {
         id: 3,
         project: firstProjectId,
+        teamId: teamId,
         title: "Epic 3",
         startDate: new Date(2019, 4, 15),
         endDate: new Date(2019, 6, 30),
@@ -57,6 +61,7 @@ export const Epics: IEpic[] = [
     {
         id: 4,
         project: secondProjectId,
+        teamId: teamId,
         title: "Epic 4",
         startDate: new Date(2019, 5, 1),
         endDate: new Date(2019, 6, 1),
@@ -70,6 +75,7 @@ export const Epics: IEpic[] = [
     {
         id: 5,
         project: secondProjectId,
+        teamId: teamId,
         title: "Epic 5",
         startDate: new Date(2019, 4, 1),
         endDate: new Date(2019, 7, 15),
@@ -83,6 +89,7 @@ export const Epics: IEpic[] = [
     {
         id: 6,
         project: thirdProjectId,
+        teamId: teamId,
         title: "Epic 6",
         startDate: new Date(2019, 4, 15),
         endDate: new Date(2019, 6, 30),
@@ -99,6 +106,7 @@ export const OtherEpics: IEpic[] = [
     {
         id: 7,
         project: firstProjectId,
+        teamId: teamId,
         title: "Epic 7",
         startDate: new Date(2019, 2, 1),
         endDate: new Date(2019, 6, 1),
@@ -112,6 +120,7 @@ export const OtherEpics: IEpic[] = [
     {
         id: 8,
         project: firstProjectId,
+        teamId: teamId,
         title: "Epic 8",
         startDate: new Date(2019, 3, 1),
         endDate: new Date(2019, 7, 15),
@@ -125,6 +134,7 @@ export const OtherEpics: IEpic[] = [
     {
         id: 9,
         project: secondProjectId,
+        teamId: teamId,
         title: "Epic 9",
         startDate: new Date(2019, 5, 15),
         endDate: new Date(2019, 9, 30),
@@ -138,6 +148,7 @@ export const OtherEpics: IEpic[] = [
     {
         id: 10,
         project: fourthProjectId,
+        teamId: teamId,
         title: "Epic 10",
         startDate: new Date(2019, 5, 15),
         endDate: new Date(2019, 7, 30),

--- a/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
+++ b/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
@@ -47,6 +47,7 @@ export function getTimelineItems(state: IEpicTimelineState): ITimelineItem[] {
         return {
             id: epic.id,
             group: epic.project,
+            teamId: epic.teamId,
             title: epic.title,
             start_time: moment(epic.startDate),
             end_time: moment(epic.endDate),


### PR DESCRIPTION
Adding a forward circle icon to navigate to Epic Roadmap pivot in backlogs hub for the selected Epic by providing the work item id and team in the URL.

To craft the URL, I need team information for every epic, which is now loaded from the first team found associated with the area path for the epic.

We can change the icon later if needed - or move it somewhere else.

![image](https://user-images.githubusercontent.com/25305030/60060307-dabaf800-96a4-11e9-8929-f5c1d3193c8b.png)
