### PR TITLE
Loading experience

### DIFF
--- a/src/PortfolioPlanning/Components/Directory/PlanDirectory.scss
+++ b/src/PortfolioPlanning/Components/Directory/PlanDirectory.scss
@@ -5,6 +5,13 @@
     overflow: auto;
     margin-top: 24px;
     background-color: $neutral-2;
+
+    .exception-message-card {
+        margin: 16px;
+    }
+}
+
+.plan-cards-container {
     display: flex;
     flex-wrap: wrap;
     align-content: flex-start;

--- a/src/PortfolioPlanning/Components/Directory/PlanDirectory.scss
+++ b/src/PortfolioPlanning/Components/Directory/PlanDirectory.scss
@@ -9,3 +9,8 @@
     flex-wrap: wrap;
     align-content: flex-start;
 }
+
+.directory-loading-spinner {
+    height: 100%;
+    width: 100%;
+}

--- a/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
@@ -48,50 +48,63 @@ export class PlanDirectory extends React.Component<IPlanDirectoryProps & IPlanDi
                 />
             );
         } else {
-            if (this.props.directoryLoadingStatus === LoadingStatus.NotLoaded) {
-                return <Spinner label="Loading..." size={SpinnerSize.large} />;
-            } else {
-                return (
-                    <Page className="plan-page">
-                        <PlanDirectoryHeader
-                            onNewPlanClick={() => {
-                                this.props.toggleNewPlanDialogVisible(true);
-                            }}
-                        />
-                        <div className="page-content plan-directory-page-content">
-                            {this.props.plans.map(plan => (
-                                <PlanCard
-                                    id={plan.id}
-                                    name={plan.name}
-                                    description={plan.description}
-                                    onClick={id => this.props.toggleSelectedPlanId(id)}
-                                />
-                            ))}
-                        </div>
-                        {this.props.newPlanDialogVisible && (
-                            <NewPlanDialog
-                                existingPlanNames={this.props.plans.map(plan => plan.name)}
-                                onDismiss={() => this.props.toggleNewPlanDialogVisible(false)}
-                                onCreate={(name: string, description: string) => {
-                                    PortfolioPlanningDataService.getInstance()
-                                        .AddPortfolioPlan(name, description)
-                                        .then(
-                                            newPlan => {
-                                                this.props.createPlan(newPlan.id, newPlan.name, newPlan.description);
-                                                this.props.toggleNewPlanDialogVisible(false);
-                                            },
-                                            reason => {
-                                                alert(`Create new plan failed: ${reason}`);
-                                            }
-                                        );
-                                }}
-                            />
-                        )}
-                    </Page>
-                );
-            }
+            return (
+                <Page className="plan-page">
+                    <PlanDirectoryHeader
+                        newPlanButtonDisabled={this.props.directoryLoadingStatus !== LoadingStatus.Loaded}
+                        onNewPlanClick={() => {
+                            this.props.toggleNewPlanDialogVisible(true);
+                        }}
+                    />
+                    {this._renderDirectoryContent()}
+                    {this._renderNewPlanDialog()}
+                </Page>
+            );
         }
     }
+
+    private _renderDirectoryContent = (): JSX.Element => {
+        return (
+            <div className="page-content plan-directory-page-content">
+                {this.props.directoryLoadingStatus === LoadingStatus.NotLoaded ? (
+                    <Spinner className="directory-loading-spinner" label="Loading..." size={SpinnerSize.large} />
+                ) : (
+                    this.props.plans.map(plan => (
+                        <PlanCard
+                            id={plan.id}
+                            name={plan.name}
+                            description={plan.description}
+                            onClick={id => this.props.toggleSelectedPlanId(id)}
+                        />
+                    ))
+                )}
+            </div>
+        );
+    };
+
+    private _renderNewPlanDialog = (): JSX.Element => {
+        return (
+            this.props.newPlanDialogVisible && (
+                <NewPlanDialog
+                    existingPlanNames={this.props.plans.map(plan => plan.name)}
+                    onDismiss={() => this.props.toggleNewPlanDialogVisible(false)}
+                    onCreate={(name: string, description: string) => {
+                        PortfolioPlanningDataService.getInstance()
+                            .AddPortfolioPlan(name, description)
+                            .then(
+                                newPlan => {
+                                    this.props.createPlan(newPlan.id, newPlan.name, newPlan.description);
+                                    this.props.toggleNewPlanDialogVisible(false);
+                                },
+                                reason => {
+                                    alert(`Create new plan failed: ${reason}`);
+                                }
+                            );
+                    }}
+                />
+            )
+        );
+    };
 }
 
 function mapStateToProps(state: IPortfolioPlanningState): IPlanDirectoryMappedProps {

--- a/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
@@ -10,6 +10,8 @@ import { IPortfolioPlanningState } from "../../Redux/Contracts";
 import PlanPage from "../PlanPage";
 import { PortfolioPlanningDataService } from "../../../Services/PortfolioPlanningDataService";
 import { PortfolioPlanningMetadata } from "../../Models/PortfolioPlanningQueryModels";
+import { EpicTimelineActions } from "../../Redux/Actions/EpicTimelineActions";
+import { LoadingStatus } from "../../Contracts";
 
 export interface IPlanDirectoryProps {}
 
@@ -33,8 +35,14 @@ export class PlanDirectory extends React.Component<IPlanDirectoryProps & IPlanDi
                     id={selectedPlan.id}
                     title={selectedPlan.name}
                     description={selectedPlan.description}
-                    backButtonClicked={() => this.props.toggleSelectedPlanId(undefined)}
-                    deleteButtonClicked={(id: string) => this.props.deletePlan(id)}
+                    backButtonClicked={() => {
+                        this.props.toggleSelectedPlanId(undefined);
+                        this.props.togglePlanLoadingStatus(LoadingStatus.NotLoaded);
+                    }}
+                    deleteButtonClicked={(id: string) => {
+                        this.props.deletePlan(id);
+                        this.props.togglePlanLoadingStatus(LoadingStatus.NotLoaded);
+                    }}
                 />
             );
         } else {
@@ -92,7 +100,8 @@ const Actions = {
     createPlan: PlanDirectoryActions.createPlan,
     deletePlan: PlanDirectoryActions.deletePlan,
     toggleSelectedPlanId: PlanDirectoryActions.toggleSelectedPlanId,
-    toggleNewPlanDialogVisible: PlanDirectoryActions.toggleNewPlanDialogVisible
+    toggleNewPlanDialogVisible: PlanDirectoryActions.toggleNewPlanDialogVisible,
+    togglePlanLoadingStatus: EpicTimelineActions.toggleLoadingStatus
 };
 
 export const ConnectedPlanDirectory = connect(

--- a/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
@@ -13,14 +13,16 @@ import { PortfolioPlanningMetadata } from "../../Models/PortfolioPlanningQueryMo
 import { EpicTimelineActions } from "../../Redux/Actions/EpicTimelineActions";
 import { LoadingStatus } from "../../Contracts";
 import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
+import { MessageCard, MessageCardSeverity } from "azure-devops-ui/MessageCard";
 
 export interface IPlanDirectoryProps {}
 
 interface IPlanDirectoryMappedProps {
+    directoryLoadingStatus: LoadingStatus;
+    exceptionMessage: string;
     selectedPlanId: string;
     plans: PortfolioPlanningMetadata[];
     newPlanDialogVisible: boolean;
-    directoryLoadingStatus: LoadingStatus;
 }
 
 export class PlanDirectory extends React.Component<IPlanDirectoryProps & IPlanDirectoryMappedProps & typeof Actions> {
@@ -64,22 +66,37 @@ export class PlanDirectory extends React.Component<IPlanDirectoryProps & IPlanDi
     }
 
     private _renderDirectoryContent = (): JSX.Element => {
-        return (
-            <div className="page-content plan-directory-page-content">
-                {this.props.directoryLoadingStatus === LoadingStatus.NotLoaded ? (
-                    <Spinner className="directory-loading-spinner" label="Loading..." size={SpinnerSize.large} />
-                ) : (
-                    this.props.plans.map(plan => (
-                        <PlanCard
-                            id={plan.id}
-                            name={plan.name}
-                            description={plan.description}
-                            onClick={id => this.props.toggleSelectedPlanId(id)}
-                        />
-                    ))
-                )}
-            </div>
-        );
+        if (this.props.directoryLoadingStatus === LoadingStatus.NotLoaded) {
+            return (
+                <Spinner
+                    className="page-content directory-loading-spinner"
+                    label="Loading..."
+                    size={SpinnerSize.large}
+                />
+            );
+        } else {
+            const exceptionMessageCard = (
+                <MessageCard className="flex-self-stretch exception-message-card" severity={MessageCardSeverity.Error}>
+                    {this.props.exceptionMessage}
+                </MessageCard>
+            );
+
+            const plans = this.props.plans.map(plan => (
+                <PlanCard
+                    id={plan.id}
+                    name={plan.name}
+                    description={plan.description}
+                    onClick={id => this.props.toggleSelectedPlanId(id)}
+                />
+            ));
+
+            return (
+                <div className="page-content plan-directory-page-content">
+                    {this.props.exceptionMessage && exceptionMessageCard}
+                    <div className="plan-cards-container">{plans}</div>
+                </div>
+            );
+        }
     };
 
     private _renderNewPlanDialog = (): JSX.Element => {
@@ -109,10 +126,11 @@ export class PlanDirectory extends React.Component<IPlanDirectoryProps & IPlanDi
 
 function mapStateToProps(state: IPortfolioPlanningState): IPlanDirectoryMappedProps {
     return {
+        directoryLoadingStatus: state.planDirectoryState.directoryLoadingStatus,
+        exceptionMessage: state.planDirectoryState.exceptionMessage,
         selectedPlanId: state.planDirectoryState.selectedPlanId,
         plans: state.planDirectoryState.plans,
-        newPlanDialogVisible: state.planDirectoryState.newPlanDialogVisible,
-        directoryLoadingStatus: state.planDirectoryState.directoryLoadingStatus
+        newPlanDialogVisible: state.planDirectoryState.newPlanDialogVisible
     };
 }
 

--- a/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
@@ -11,7 +11,6 @@ import PlanPage from "../PlanPage";
 import { PortfolioPlanningDataService } from "../../../Services/PortfolioPlanningDataService";
 import { PortfolioPlanningMetadata } from "../../Models/PortfolioPlanningQueryModels";
 import { EpicTimelineActions } from "../../Redux/Actions/EpicTimelineActions";
-import { LoadingStatus } from "../../Contracts";
 
 export interface IPlanDirectoryProps {}
 
@@ -37,11 +36,11 @@ export class PlanDirectory extends React.Component<IPlanDirectoryProps & IPlanDi
                     description={selectedPlan.description}
                     backButtonClicked={() => {
                         this.props.toggleSelectedPlanId(undefined);
-                        this.props.togglePlanLoadingStatus(LoadingStatus.NotLoaded);
+                        this.props.resetPlanState();
                     }}
                     deleteButtonClicked={(id: string) => {
                         this.props.deletePlan(id);
-                        this.props.togglePlanLoadingStatus(LoadingStatus.NotLoaded);
+                        this.props.resetPlanState();
                     }}
                 />
             );
@@ -101,7 +100,8 @@ const Actions = {
     deletePlan: PlanDirectoryActions.deletePlan,
     toggleSelectedPlanId: PlanDirectoryActions.toggleSelectedPlanId,
     toggleNewPlanDialogVisible: PlanDirectoryActions.toggleNewPlanDialogVisible,
-    togglePlanLoadingStatus: EpicTimelineActions.toggleLoadingStatus
+    togglePlanLoadingStatus: EpicTimelineActions.toggleLoadingStatus,
+    resetPlanState: EpicTimelineActions.resetPlanState
 };
 
 export const ConnectedPlanDirectory = connect(

--- a/src/PortfolioPlanning/Components/Directory/PlanDirectoryHeader.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanDirectoryHeader.tsx
@@ -2,11 +2,12 @@ import * as React from "react";
 import { TitleSize, Header } from "azure-devops-ui/Header";
 import "./PlanDirectoryHeader.scss";
 
-export interface PlanDirectoryProps {
+export interface IPlanDirectoryHeaderProps {
+    newPlanButtonDisabled: boolean;
     onNewPlanClick: () => void;
 }
 
-export default class PlanDirectoryHeader extends React.Component<PlanDirectoryProps> {
+export default class PlanDirectoryHeader extends React.Component<IPlanDirectoryHeaderProps> {
     constructor(props) {
         super(props);
     }
@@ -20,7 +21,8 @@ export default class PlanDirectoryHeader extends React.Component<PlanDirectoryPr
                     {
                         id: "new-plan",
                         text: "New plan",
-                        onActivate: this.props.onNewPlanClick
+                        onActivate: this.props.onNewPlanClick,
+                        disabled: this.props.newPlanButtonDisabled
                     }
                 ]}
             />

--- a/src/PortfolioPlanning/Components/EpicTimeline.tsx
+++ b/src/PortfolioPlanning/Components/EpicTimeline.tsx
@@ -45,7 +45,7 @@ export class EpicTimeline extends React.Component<IEpicTimelineProps, IEpicTimel
     }
 
     public render(): JSX.Element {
-        if (this.props.planLoadingStatus === LoadingStatus.Loading) {
+        if (this.props.planLoadingStatus === LoadingStatus.NotLoaded) {
             return <Spinner label="Loading..." size={SpinnerSize.large} />;
         } else {
             const selectedItem = this.props.items.find(item => item.id === this.props.selectedItemId);

--- a/src/PortfolioPlanning/Components/EpicTimeline.tsx
+++ b/src/PortfolioPlanning/Components/EpicTimeline.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as moment from "moment";
-import { ITimelineGroup, ITimelineItem, ProgressTrackingCriteria, ITeam } from "../Contracts";
+import { ITimelineGroup, ITimelineItem, ProgressTrackingCriteria, ITeam, LoadingStatus } from "../Contracts";
 import Timeline from "react-calendar-timeline";
 import "./EpicTimeline.scss";
 import { IEpicTimelineState, IPortfolioPlanningState } from "../Redux/Contracts";
@@ -18,6 +18,7 @@ import { AddEpicDialog } from "./AddEpicDialog";
 import { ComboBox } from "office-ui-fabric-react/lib/ComboBox";
 import { ProgressDetails } from "../../Common/react/Components/ProgressDetails/ProgressDetails";
 import { InfoIcon } from "../../Common/react/Components/InfoIcon/InfoIcon";
+import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
 
 const day = 60 * 60 * 24 * 1000;
 const week = day * 7;
@@ -33,6 +34,7 @@ interface IEpicTimelineMappedProps {
     setDatesDialogHidden: boolean;
     selectedItemId: number;
     progressTrackingCriteria: ProgressTrackingCriteria;
+    planLoadingStatus: LoadingStatus;
 }
 
 export type IEpicTimelineProps = IEpicTimelineOwnProps & IEpicTimelineMappedProps & typeof Actions;
@@ -43,132 +45,136 @@ export class EpicTimeline extends React.Component<IEpicTimelineProps, IEpicTimel
     }
 
     public render(): JSX.Element {
-        const selectedItem = this.props.items.find(item => item.id === this.props.selectedItemId);
+        if (this.props.planLoadingStatus === LoadingStatus.Loading) {
+            return <Spinner label="Loading..." size={SpinnerSize.large} />;
+        } else {
+            const selectedItem = this.props.items.find(item => item.id === this.props.selectedItemId);
 
-        const selectedProgressCriteriaKey =
-            this.props.progressTrackingCriteria === ProgressTrackingCriteria.CompletedCount
-                ? "completedCount"
-                : "storyPoints";
+            const selectedProgressCriteriaKey =
+                this.props.progressTrackingCriteria === ProgressTrackingCriteria.CompletedCount
+                    ? "completedCount"
+                    : "storyPoints";
 
-        const [defaultTimeStart, defaultTimeEnd] = this._getDefaultTimes(this.props.items);
+            const [defaultTimeStart, defaultTimeEnd] = this._getDefaultTimes(this.props.items);
 
-        const forwardCircleStyle = {
-            padding: "0px 0px 0px 10px"
-        };
+            const forwardCircleStyle = {
+                padding: "0px 0px 0px 10px"
+            };
 
-        return (
-            <div>
-                <div className="configuration-container">
-                    <div className="progress-options">
-                        <div className="progress-options-label">Track Progress Using: </div>
-                        <ComboBox
-                            className="progress-options-dropdown"
-                            selectedKey={selectedProgressCriteriaKey}
-                            allowFreeform={false}
-                            autoComplete="off"
-                            options={[
-                                {
-                                    key: "completedCount",
-                                    text: ProgressTrackingCriteria.CompletedCount
-                                },
-                                {
-                                    key: "storyPoints",
-                                    text: ProgressTrackingCriteria.StoryPoints
-                                }
-                            ]}
-                            onChanged={this._onProgressTrackingCriteriaChanged}
-                        />
+            return (
+                <div>
+                    <div className="configuration-container">
+                        <div className="progress-options">
+                            <div className="progress-options-label">Track Progress Using: </div>
+                            <ComboBox
+                                className="progress-options-dropdown"
+                                selectedKey={selectedProgressCriteriaKey}
+                                allowFreeform={false}
+                                autoComplete="off"
+                                options={[
+                                    {
+                                        key: "completedCount",
+                                        text: ProgressTrackingCriteria.CompletedCount
+                                    },
+                                    {
+                                        key: "storyPoints",
+                                        text: ProgressTrackingCriteria.StoryPoints
+                                    }
+                                ]}
+                                onChanged={this._onProgressTrackingCriteriaChanged}
+                            />
+                        </div>
+                        <button className="epictimeline-add-epic-button" onClick={this._onAddEpicClick}>
+                            Add Epic
+                        </button>
+                        <button
+                            className="epictimeline-add-epic-button"
+                            disabled={!this.props.selectedItemId}
+                            onClick={this._onRemoveSelectedEpicClick}
+                        >
+                            Remove selected epic from plan
+                        </button>
                     </div>
-                    <button className="epictimeline-add-epic-button" onClick={this._onAddEpicClick}>
-                        Add Epic
-                    </button>
-                    <button
-                        className="epictimeline-add-epic-button"
-                        disabled={!this.props.selectedItemId}
-                        onClick={this._onRemoveSelectedEpicClick}
-                    >
-                        Remove selected epic from plan
-                    </button>
-                </div>
-                <Timeline
-                    groups={this.props.groups}
-                    items={this.props.items}
-                    defaultTimeStart={defaultTimeStart}
-                    defaultTimeEnd={defaultTimeEnd}
-                    canChangeGroup={false}
-                    stackItems={true}
-                    dragSnap={day}
-                    minZoom={week}
-                    canResize={"both"}
-                    minResizeWidth={50}
-                    onItemResize={this._onItemResize}
-                    onItemMove={this._onItemMove}
-                    moveResizeValidator={this._validateResize}
-                    selecte={[this.props.selectedItemId]}
-                    onItemSelect={itemId => this.props.onSetSelectedItemId(itemId)}
-                    onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
-                    itemRenderer={({ item, itemContext, getItemProps }) => {
-                        return (
-                            <div {...getItemProps(item.itemProps)}>
-                                <div
-                                    style={{
-                                        maxHeight: `${itemContext.dimensions.height}`,
-                                        display: "flex",
-                                        justifyContent: "space-between",
-                                        overflow: "hidden",
-                                        marginRight: "5px",
-                                        alignItems: "baseline"
-                                    }}
-                                >
-                                    {itemContext.title}
+                    <Timeline
+                        groups={this.props.groups}
+                        items={this.props.items}
+                        defaultTimeStart={defaultTimeStart}
+                        defaultTimeEnd={defaultTimeEnd}
+                        canChangeGroup={false}
+                        stackItems={true}
+                        dragSnap={day}
+                        minZoom={week}
+                        canResize={"both"}
+                        minResizeWidth={50}
+                        onItemResize={this._onItemResize}
+                        onItemMove={this._onItemMove}
+                        moveResizeValidator={this._validateResize}
+                        selecte={[this.props.selectedItemId]}
+                        onItemSelect={itemId => this.props.onSetSelectedItemId(itemId)}
+                        onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
+                        itemRenderer={({ item, itemContext, getItemProps }) => {
+                            return (
+                                <div {...getItemProps(item.itemProps)}>
                                     <div
                                         style={{
+                                            maxHeight: `${itemContext.dimensions.height}`,
                                             display: "flex",
-                                            justifyContent: "flex-end"
+                                            justifyContent: "space-between",
+                                            overflow: "hidden",
+                                            marginRight: "5px",
+                                            alignItems: "baseline"
                                         }}
                                     >
-                                        <InfoIcon
-                                            id={item.id}
-                                            onClick={() => this.props.onToggleSetDatesDialogHidden(false)}
-                                        />
-                                        <ProgressDetails
-                                            completed={item.itemProps.completed}
-                                            total={item.itemProps.total}
-                                            onClick={() => {}}
-                                        />
+                                        {itemContext.title}
                                         <div
-                                            className="bowtie-icon bowtie-navigate-forward-circle"
-                                            style={forwardCircleStyle}
-                                            onClick={() => this.navigateToEpicRoadmap(item)}
+                                            style={{
+                                                display: "flex",
+                                                justifyContent: "flex-end"
+                                            }}
                                         >
-                                            &nbsp;
+                                            <InfoIcon
+                                                id={item.id}
+                                                onClick={() => this.props.onToggleSetDatesDialogHidden(false)}
+                                            />
+                                            <ProgressDetails
+                                                completed={item.itemProps.completed}
+                                                total={item.itemProps.total}
+                                                onClick={() => {}}
+                                            />
+                                            <div
+                                                className="bowtie-icon bowtie-navigate-forward-circle"
+                                                style={forwardCircleStyle}
+                                                onClick={() => this.navigateToEpicRoadmap(item)}
+                                            >
+                                                &nbsp;
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                        );
-                    }}
-                />
-                {this._renderAddEpicDialog()}
-                {this.props.selectedItemId && (
-                    <DetailsDialog
-                        key={Date.now()} // TODO: Is there a better way to reset the state?
-                        id={this.props.selectedItemId}
-                        title={selectedItem.title}
-                        startDate={selectedItem.start_time}
-                        endDate={selectedItem.end_time}
-                        hidden={this.props.setDatesDialogHidden}
-                        save={(id, startDate, endDate) => {
-                            this.props.onUpdateStartDate(id, startDate);
-                            this.props.onUpdateEndDate(id, endDate);
-                        }}
-                        close={() => {
-                            this.props.onToggleSetDatesDialogHidden(true);
+                            );
                         }}
                     />
-                )}
-            </div>
-        );
+                    {this._renderAddEpicDialog()}
+                    {this.props.selectedItemId && (
+                        <DetailsDialog
+                            key={Date.now()} // TODO: Is there a better way to reset the state?
+                            id={this.props.selectedItemId}
+                            title={selectedItem.title}
+                            startDate={selectedItem.start_time}
+                            endDate={selectedItem.end_time}
+                            hidden={this.props.setDatesDialogHidden}
+                            save={(id, startDate, endDate) => {
+                                this.props.onUpdateStartDate(id, startDate);
+                                this.props.onUpdateEndDate(id, endDate);
+                            }}
+                            close={() => {
+                                this.props.onToggleSetDatesDialogHidden(true);
+                            }}
+                        />
+                    )}
+                </div>
+            );
+        }
     }
 
     private _validateResize(action: string, item: ITimelineItem, time: number, resizeEdge: string) {
@@ -281,7 +287,8 @@ function mapStateToProps(state: IPortfolioPlanningState): IEpicTimelineMappedPro
         addEpicDialogOpen: getAddEpicDialogOpen(state.epicTimelineState),
         setDatesDialogHidden: getSetDatesDialogHidden(state.epicTimelineState),
         selectedItemId: state.epicTimelineState.selectedItemId,
-        progressTrackingCriteria: getProgressTrackingCriteria(state.epicTimelineState)
+        progressTrackingCriteria: getProgressTrackingCriteria(state.epicTimelineState),
+        planLoadingStatus: state.epicTimelineState.planLoadingStatus
     };
 }
 

--- a/src/PortfolioPlanning/Contracts.ts
+++ b/src/PortfolioPlanning/Contracts.ts
@@ -61,7 +61,7 @@ export enum ProgressTrackingCriteria {
 }
 
 export enum LoadingStatus {
-    Loading,
+    NotLoaded,
     Loaded,
     LoadedWithErrors
 }

--- a/src/PortfolioPlanning/Contracts.ts
+++ b/src/PortfolioPlanning/Contracts.ts
@@ -62,6 +62,5 @@ export enum ProgressTrackingCriteria {
 
 export enum LoadingStatus {
     NotLoaded,
-    Loaded,
-    LoadedWithErrors
+    Loaded
 }

--- a/src/PortfolioPlanning/Contracts.ts
+++ b/src/PortfolioPlanning/Contracts.ts
@@ -59,3 +59,9 @@ export enum ProgressTrackingCriteria {
     CompletedCount = "Completed Count",
     StoryPoints = "Story Points"
 }
+
+export enum LoadingStatus {
+    Loading,
+    Loaded,
+    LoadedWithErrors
+}

--- a/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
+++ b/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
@@ -1,5 +1,5 @@
 import { createAction, ActionsUnion } from "../../../Common/redux/Helpers/ActionHelper";
-import { ProgressTrackingCriteria, IAddEpics, IRemoveEpic } from "../../Contracts";
+import { ProgressTrackingCriteria, IAddEpics, IRemoveEpic, LoadingStatus } from "../../Contracts";
 import moment = require("moment");
 import { PortfolioPlanningFullContentQueryResult } from "../../Models/PortfolioPlanningQueryModels";
 import { Action } from "redux";
@@ -17,7 +17,8 @@ export const enum EpicTimelineActionTypes {
     CloseAddEpicDialog = "EpicTimeline/CloseAddEpicDialog",
     AddEpics = "EpicTimeline/AddEpics",
     RemoveEpic = "EpicTimeline/RemoveEpic",
-    ToggleProgressTrackingCriteria = "EpicTimeline/ToggleProgressTrackingCriteria"
+    ToggleProgressTrackingCriteria = "EpicTimeline/ToggleProgressTrackingCriteria",
+    ToggleLoadingStatus = "EpicTimeline/ToggleLoadingStatus"
 }
 
 export const EpicTimelineActions = {
@@ -49,7 +50,9 @@ export const EpicTimelineActions = {
     toggleProgressTrackingCriteria: (criteria: ProgressTrackingCriteria) =>
         createAction(EpicTimelineActionTypes.ToggleProgressTrackingCriteria, {
             criteria
-        })
+        }),
+    toggleLoadingStatus: (status: LoadingStatus) =>
+        createAction(EpicTimelineActionTypes.ToggleLoadingStatus, { status })
 };
 
 export type EpicTimelineActions = ActionsUnion<typeof EpicTimelineActions>;

--- a/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
+++ b/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
@@ -18,7 +18,8 @@ export const enum EpicTimelineActionTypes {
     AddEpics = "EpicTimeline/AddEpics",
     RemoveEpic = "EpicTimeline/RemoveEpic",
     ToggleProgressTrackingCriteria = "EpicTimeline/ToggleProgressTrackingCriteria",
-    ToggleLoadingStatus = "EpicTimeline/ToggleLoadingStatus"
+    ToggleLoadingStatus = "EpicTimeline/ToggleLoadingStatus",
+    ResetPlanState = "EpicTimeline/ResetPlanState"
 }
 
 export const EpicTimelineActions = {
@@ -52,7 +53,8 @@ export const EpicTimelineActions = {
             criteria
         }),
     toggleLoadingStatus: (status: LoadingStatus) =>
-        createAction(EpicTimelineActionTypes.ToggleLoadingStatus, { status })
+        createAction(EpicTimelineActionTypes.ToggleLoadingStatus, { status }),
+    resetPlanState: () => createAction(EpicTimelineActionTypes.ResetPlanState)
 };
 
 export type EpicTimelineActions = ActionsUnion<typeof EpicTimelineActions>;

--- a/src/PortfolioPlanning/Redux/Contracts.ts
+++ b/src/PortfolioPlanning/Redux/Contracts.ts
@@ -1,4 +1,4 @@
-import { IProject, IEpic, ProgressTrackingCriteria, ITeam } from "../Contracts";
+import { IProject, IEpic, ProgressTrackingCriteria, ITeam, LoadingStatus } from "../Contracts";
 import { PortfolioPlanningMetadata } from "../Models/PortfolioPlanningQueryModels";
 
 export interface IPortfolioPlanningState {
@@ -15,6 +15,7 @@ export interface IEpicTimelineState {
     setDatesDialogHidden: boolean;
     selectedItemId: number;
     progressTrackingCriteria: ProgressTrackingCriteria;
+    planLoadingStatus: LoadingStatus;
 }
 
 export interface IPlanDirectoryState {

--- a/src/PortfolioPlanning/Redux/Contracts.ts
+++ b/src/PortfolioPlanning/Redux/Contracts.ts
@@ -7,6 +7,8 @@ export interface IPortfolioPlanningState {
 }
 
 export interface IEpicTimelineState {
+    planLoadingStatus: LoadingStatus;
+    exceptionMessage: string;
     projects: IProject[];
     teams: { [teamId: string]: ITeam };
     epics: IEpic[];
@@ -15,11 +17,11 @@ export interface IEpicTimelineState {
     setDatesDialogHidden: boolean;
     selectedItemId: number;
     progressTrackingCriteria: ProgressTrackingCriteria;
-    planLoadingStatus: LoadingStatus;
 }
 
 export interface IPlanDirectoryState {
     directoryLoadingStatus: LoadingStatus;
+    exceptionMessage: string;
     selectedPlanId: string;
     newPlanDialogVisible: boolean;
     plans: PortfolioPlanningMetadata[];

--- a/src/PortfolioPlanning/Redux/Contracts.ts
+++ b/src/PortfolioPlanning/Redux/Contracts.ts
@@ -19,6 +19,7 @@ export interface IEpicTimelineState {
 }
 
 export interface IPlanDirectoryState {
+    directoryLoadingStatus: LoadingStatus;
     selectedPlanId: string;
     newPlanDialogVisible: boolean;
     plans: PortfolioPlanningMetadata[];

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -80,6 +80,19 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 const { status } = action.payload;
 
                 draft.planLoadingStatus = status;
+
+                break;
+            }
+            case EpicTimelineActionTypes.ResetPlanState: {
+                draft.planLoadingStatus = LoadingStatus.NotLoaded;
+                draft.selectedItemId = undefined;
+                draft.setDatesDialogHidden = true;
+                draft.addEpicDialogOpen = false;
+                draft.epics = [];
+                draft.projects = [];
+                draft.teams = {};
+
+                break;
             }
         }
     });
@@ -92,7 +105,7 @@ export function getDefaultState(): IEpicTimelineState {
         epics: [],
         message: "Initial message",
         addEpicDialogOpen: false,
-        setDatesDialogHidden: false,
+        setDatesDialogHidden: true,
         selectedItemId: null,
         progressTrackingCriteria: ProgressTrackingCriteria.CompletedCount,
         planLoadingStatus: LoadingStatus.NotLoaded

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -6,7 +6,7 @@ import {
     PortfolioItemDeletedAction
 } from "../Actions/EpicTimelineActions";
 import produce from "immer";
-import { ProgressTrackingCriteria } from "../../Contracts";
+import { ProgressTrackingCriteria, LoadingStatus } from "../../Contracts";
 import { MergeType } from "../../Models/PortfolioPlanningQueryModels";
 
 export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimelineActions): IEpicTimelineState {
@@ -87,7 +87,8 @@ export function getDefaultState(): IEpicTimelineState {
         addEpicDialogOpen: false,
         setDatesDialogHidden: false,
         selectedItemId: null,
-        progressTrackingCriteria: ProgressTrackingCriteria.CompletedCount
+        progressTrackingCriteria: ProgressTrackingCriteria.CompletedCount,
+        planLoadingStatus: LoadingStatus.Loading
     };
 }
 

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -57,7 +57,9 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 break;
             }
             case EpicTimelineActionTypes.PortfolioItemsReceived:
-                return handlePortfolioItemsReceived(state, action as PortfolioItemsReceivedAction);
+                draft.planLoadingStatus = LoadingStatus.Loaded;
+
+                return handlePortfolioItemsReceived(draft, action as PortfolioItemsReceivedAction);
 
             case EpicTimelineActionTypes.OpenAddEpicDialog: {
                 draft.addEpicDialogOpen = true;
@@ -74,6 +76,11 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 draft.progressTrackingCriteria = action.payload.criteria;
                 break;
             }
+            case EpicTimelineActionTypes.ToggleLoadingStatus: {
+                const { status } = action.payload;
+
+                draft.planLoadingStatus = status;
+            }
         }
     });
 }
@@ -88,7 +95,7 @@ export function getDefaultState(): IEpicTimelineState {
         setDatesDialogHidden: false,
         selectedItemId: null,
         progressTrackingCriteria: ProgressTrackingCriteria.CompletedCount,
-        planLoadingStatus: LoadingStatus.Loading
+        planLoadingStatus: LoadingStatus.NotLoaded
     };
 }
 

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -100,6 +100,8 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
 
 export function getDefaultState(): IEpicTimelineState {
     return {
+        planLoadingStatus: LoadingStatus.NotLoaded,
+        exceptionMessage: "",
         projects: [],
         teams: {},
         epics: [],
@@ -107,8 +109,7 @@ export function getDefaultState(): IEpicTimelineState {
         addEpicDialogOpen: false,
         setDatesDialogHidden: true,
         selectedItemId: null,
-        progressTrackingCriteria: ProgressTrackingCriteria.CompletedCount,
-        planLoadingStatus: LoadingStatus.NotLoaded
+        progressTrackingCriteria: ProgressTrackingCriteria.CompletedCount
     };
 }
 

--- a/src/PortfolioPlanning/Redux/Reducers/PlanDirectoryReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/PlanDirectoryReducer.ts
@@ -1,6 +1,7 @@
 import { IPlanDirectoryState } from "../Contracts";
 import produce from "immer";
 import { PlanDirectoryActions, PlanDirectoryActionTypes } from "../Actions/PlanDirectoryActions";
+import { LoadingStatus } from "../../Contracts";
 
 export function planDirectoryReducer(state: IPlanDirectoryState, action: PlanDirectoryActions): IPlanDirectoryState {
     return produce(state || getDefaultState(), (draft: IPlanDirectoryState) => {
@@ -9,6 +10,7 @@ export function planDirectoryReducer(state: IPlanDirectoryState, action: PlanDir
                 const { directoryData } = action.payload;
 
                 draft.plans = directoryData.entries;
+                draft.directoryLoadingStatus = LoadingStatus.Loaded;
 
                 break;
             }
@@ -57,39 +59,7 @@ export function getDefaultState(): IPlanDirectoryState {
     return {
         selectedPlanId: undefined,
         plans: [],
-        newPlanDialogVisible: false
-        // plans: [
-        //     {
-        //         id: "1",
-        //         name: "Q1 Planning",
-        //         description: "Features we plan to deliver Q1 of this year",
-        //         createdOn: new Date()
-        //     },
-        //     {
-        //         id: "2",
-        //         name: "Q2 Roadmap",
-        //         description:
-        //             "Roadmap of features our organization plans to deliver in Q2",
-        //         createdOn: new Date()
-        //     },
-        //     {
-        //         id: "3",
-        //         name: "Contoso Team's OKRs",
-        //         description: "Contoso OKRs",
-        //         createdOn: new Date()
-        //     },
-        //     {
-        //         id: "4",
-        //         name: "Contoso Team's OKRs",
-        //         description: "Contoso OKRs",
-        //         createdOn: new Date()
-        //     },
-        //     {
-        //         id: "5",
-        //         name: "Contoso Team's OKRs",
-        //         description: "Contoso OKRs",
-        //         createdOn: new Date()
-        //     }
-        // ],
+        newPlanDialogVisible: false,
+        directoryLoadingStatus: LoadingStatus.NotLoaded
     };
 }

--- a/src/PortfolioPlanning/Redux/Reducers/PlanDirectoryReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/PlanDirectoryReducer.ts
@@ -9,8 +9,9 @@ export function planDirectoryReducer(state: IPlanDirectoryState, action: PlanDir
             case PlanDirectoryActionTypes.Initialize: {
                 const { directoryData } = action.payload;
 
-                draft.plans = directoryData.entries;
                 draft.directoryLoadingStatus = LoadingStatus.Loaded;
+                draft.exceptionMessage = directoryData.exceptionMessage;
+                draft.plans = directoryData.entries;
 
                 break;
             }
@@ -57,9 +58,10 @@ export function planDirectoryReducer(state: IPlanDirectoryState, action: PlanDir
 
 export function getDefaultState(): IPlanDirectoryState {
     return {
+        directoryLoadingStatus: LoadingStatus.NotLoaded,
+        exceptionMessage: "",
         selectedPlanId: undefined,
         plans: [],
-        newPlanDialogVisible: false,
-        directoryLoadingStatus: LoadingStatus.NotLoaded
+        newPlanDialogVisible: false
     };
 }

--- a/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
@@ -2,6 +2,7 @@ import { effects, SagaIterator } from "redux-saga";
 import { PortfolioPlanningDataService } from "../../../Services/PortfolioPlanningDataService";
 import { PlanDirectoryActions, PlanDirectoryActionTypes } from "../Actions/PlanDirectoryActions";
 import { ActionsOfType } from "../Helpers";
+import { PortfolioPlanningDirectory } from "../../Models/PortfolioPlanningQueryModels";
 
 export function* planDirectorySaga(): SagaIterator {
     yield effects.call(initializePlanDirectory);
@@ -11,7 +12,7 @@ export function* planDirectorySaga(): SagaIterator {
 export function* initializePlanDirectory(): SagaIterator {
     const service = PortfolioPlanningDataService.getInstance();
 
-    const allPlans = yield effects.call([service, service.GetAllPortfolioPlans]);
+    const allPlans: PortfolioPlanningDirectory = yield effects.call([service, service.GetAllPortfolioPlans]);
 
     yield effects.put(PlanDirectoryActions.initialize(allPlans));
 }


### PR DESCRIPTION
- Added spinner for loading on directory. We only load this once so navigating back to the directory won't reload.
- Added spinner for loading of the plan. Each time they navigate to the plan the spinner will show while loading.
- Added an action to reset the local plan state when navigating away from it.
- Show an error message card on the directory when it doesn't load correctly.