### PR TITLE
Show team and projects in plan header

### DIFF
--- a/src/PortfolioPlanning/Components/Directory/PlanCard.scss
+++ b/src/PortfolioPlanning/Components/Directory/PlanCard.scss
@@ -1,4 +1,5 @@
 @import "node_modules/azure-devops-ui/Core/_platformCommon.scss";
+@import "node_modules/azure-devops-ui/Core/core.scss";
 
 .plan-card-container {
     margin: 16px 16px;
@@ -6,14 +7,34 @@
 
 .plan-card {
     width: 240px;
-    height: 200px;
+    height: 300px;
     background-color: $white;
+    @extend .font-weight-semibold;
 
     .name {
-        padding-bottom: 4px;
+        @extend .title-s;
+        height: 32px;
     }
 
     .description {
-        padding-bottom: 8px;
+        @extend .body-m;
+        height: 40px;
+    }
+
+    .projects-container,
+    .teams-container {
+        display: flex;
+        flex-direction: column;
+        margin-top: $spacing-16;
+
+        .projects-label,
+        .teams-label {
+            @extend .body-s;
+        }
+
+        .projects-list,
+        .teams-list {
+            @extend .body-m;
+        }
     }
 }

--- a/src/PortfolioPlanning/Components/Directory/PlanCard.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanCard.tsx
@@ -16,8 +16,16 @@ export default class PlanCard extends React.Component<PlanCardProps> {
             <div className="plan-card-container" onClick={() => this.props.onClick(this.props.id)}>
                 <Card className="plan-card">
                     <div className="flex-column">
-                        <div className="title-s name">{this.props.name}</div>
-                        <div className="body-m description">{this.props.description}</div>
+                        <div className="name">{this.props.name}</div>
+                        <div className="description">{this.props.description}</div>
+                        <div className="teams-container">
+                            <div className="teams-label">Teams</div>
+                            <div>Fabrikam, Contoso, WIT X</div>
+                        </div>
+                        <div className="projects-container">
+                            <div className="projects-label">Projects</div>
+                            <div>Fabrikam, AzureDevOps</div>
+                        </div>
                     </div>
                 </Card>
             </div>

--- a/src/PortfolioPlanning/Components/Directory/PlanCard.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanCard.tsx
@@ -20,11 +20,11 @@ export default class PlanCard extends React.Component<PlanCardProps> {
                         <div className="description">{this.props.description}</div>
                         <div className="teams-container">
                             <div className="teams-label">Teams</div>
-                            <div>Fabrikam, Contoso, WIT X</div>
+                            <div>TODO</div>
                         </div>
                         <div className="projects-container">
                             <div className="projects-label">Projects</div>
-                            <div>Fabrikam, AzureDevOps</div>
+                            <div>TODO</div>
                         </div>
                     </div>
                 </Card>

--- a/src/PortfolioPlanning/Components/EpicTimeline.tsx
+++ b/src/PortfolioPlanning/Components/EpicTimeline.tsx
@@ -63,7 +63,7 @@ export class EpicTimeline extends React.Component<IEpicTimelineProps, IEpicTimel
             };
 
             return (
-                <div>
+                <div className="page-content">
                     <PlanSummary projects={this.props.groups.map(group => group.title)} teams={this.props.teams} />
                     <div className="configuration-container">
                         <div className="progress-options">

--- a/src/PortfolioPlanning/Components/EpicTimeline.tsx
+++ b/src/PortfolioPlanning/Components/EpicTimeline.tsx
@@ -124,7 +124,8 @@ export class EpicTimeline extends React.Component<IEpicTimelineProps, IEpicTimel
                                             justifyContent: "space-between",
                                             overflow: "hidden",
                                             marginRight: "5px",
-                                            alignItems: "baseline"
+                                            alignItems: "baseline",
+                                            whiteSpace: "nowrap"
                                         }}
                                     >
                                         {itemContext.title}

--- a/src/PortfolioPlanning/Components/EpicTimeline.tsx
+++ b/src/PortfolioPlanning/Components/EpicTimeline.tsx
@@ -19,6 +19,7 @@ import { ComboBox } from "office-ui-fabric-react/lib/ComboBox";
 import { ProgressDetails } from "../../Common/react/Components/ProgressDetails/ProgressDetails";
 import { InfoIcon } from "../../Common/react/Components/InfoIcon/InfoIcon";
 import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
+import { PlanSummary } from "./PlanSummary";
 
 const day = 60 * 60 * 24 * 1000;
 const week = day * 7;
@@ -63,6 +64,7 @@ export class EpicTimeline extends React.Component<IEpicTimelineProps, IEpicTimel
 
             return (
                 <div>
+                    <PlanSummary projects={this.props.groups.map(group => group.title)} teams={this.props.teams} />
                     <div className="configuration-container">
                         <div className="progress-options">
                             <div className="progress-options-label">Track Progress Using: </div>

--- a/src/PortfolioPlanning/Components/PlanHeader.tsx
+++ b/src/PortfolioPlanning/Components/PlanHeader.tsx
@@ -12,25 +12,27 @@ export interface PlanHeaderProps {
 export default class PlanHeader extends React.Component<PlanHeaderProps> {
     public render() {
         return (
-            <Header
-                title={this.props.name}
-                titleSize={TitleSize.Large}
-                description={this.props.description}
-                backButtonProps={{ onClick: this.props.backButtonClicked }}
-                commandBarItems={[
-                    {
-                        iconProps: {
-                            iconName: "Delete"
-                        },
-                        id: "delete-plan",
-                        important: false,
-                        onActivate: () => {
-                            this.props.deleteButtonClicked(this.props.id);
-                        },
-                        text: "Delete plan"
-                    }
-                ]}
-            />
+            <>
+                <Header
+                    title={this.props.name}
+                    titleSize={TitleSize.Large}
+                    description={this.props.description}
+                    backButtonProps={{ onClick: this.props.backButtonClicked }}
+                    commandBarItems={[
+                        {
+                            iconProps: {
+                                iconName: "Delete"
+                            },
+                            id: "delete-plan",
+                            important: false,
+                            onActivate: () => {
+                                this.props.deleteButtonClicked(this.props.id);
+                            },
+                            text: "Delete plan"
+                        }
+                    ]}
+                />
+            </>
         );
     }
 }

--- a/src/PortfolioPlanning/Components/PlanSummary.scss
+++ b/src/PortfolioPlanning/Components/PlanSummary.scss
@@ -5,7 +5,7 @@
     display: flex;
 
     .summary-item {
-        margin: $spacing-4;
+        padding-right: $spacing-32;
     }
 
     .projects-teams-label {

--- a/src/PortfolioPlanning/Components/PlanSummary.scss
+++ b/src/PortfolioPlanning/Components/PlanSummary.scss
@@ -6,6 +6,7 @@
 
     .summary-item {
         padding-right: $spacing-32;
+        max-width: 400px;
     }
 
     .projects-teams-label {

--- a/src/PortfolioPlanning/Components/PlanSummary.scss
+++ b/src/PortfolioPlanning/Components/PlanSummary.scss
@@ -1,0 +1,18 @@
+@import "node_modules/azure-devops-ui/Core/_platformCommon.scss";
+@import "node_modules/azure-devops-ui/Core/core.scss";
+
+.plan-summary {
+    display: flex;
+
+    .summary-item {
+        margin: $spacing-4;
+    }
+
+    .projects-teams-label {
+        @extend .title-xs;
+        color: $secondary-text;
+    }
+    .projects-teams-content {
+        @extend .title-s;
+    }
+}

--- a/src/PortfolioPlanning/Components/PlanSummary.tsx
+++ b/src/PortfolioPlanning/Components/PlanSummary.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import "./PlanSummary.scss";
 import { ITeam } from "../Contracts";
 
 export interface IPlanSummaryProps {
@@ -13,14 +14,14 @@ export const PlanSummary = (props: IPlanSummaryProps) => {
         .join(", ");
 
     return (
-        <div style={{ display: "flex" }} className="page-content">
-            <div>
-                <div>Projects</div>
-                <div>{projects}</div>
+        <div className="plan-summary">
+            <div className="summary-item">
+                <div className="projects-teams-label">Teams</div>
+                <div className="projects-teams-content">{teams}</div>
             </div>
-            <div>
-                <div>Teams</div>
-                <div>{teams}</div>
+            <div className="summary-item">
+                <div className="projects-teams-label">Projects</div>
+                <div className="projects-teams-content">{projects}</div>
             </div>
         </div>
     );

--- a/src/PortfolioPlanning/Components/PlanSummary.tsx
+++ b/src/PortfolioPlanning/Components/PlanSummary.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { ITeam } from "../Contracts";
+
+export interface IPlanSummaryProps {
+    projects: string[];
+    teams: { [teamId: string]: ITeam };
+}
+
+export const PlanSummary = (props: IPlanSummaryProps) => {
+    const projects = props.projects.join(", ");
+    const teams = Object.keys(props.teams)
+        .map(teamId => props.teams[teamId].teamName)
+        .join(", ");
+
+    return (
+        <div style={{ display: "flex" }} className="page-content">
+            <div>
+                <div>Projects</div>
+                <div>{projects}</div>
+            </div>
+            <div>
+                <div>Teams</div>
+                <div>{teams}</div>
+            </div>
+        </div>
+    );
+};

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -66,7 +66,7 @@
             "description": "Portfolio planning.",
             "targets": ["ms.vss-work-web.work-hub-group"],
             "properties": {
-                "name": "Portfolio planning",
+                "name": "Portfolio Plans",
                 "uri": "dist/PortfolioPlanning.html",
                 "dynamic": true
             }


### PR DESCRIPTION
On the plan page it shows the teams and projects. Also added some small styling/overflow changes to other areas. 

Still need to pass the data to the header somehow.