### PR TITLE
Show projects and teams on card metadata

### DIFF
--- a/src/PortfolioPlanning/Components/Directory/PlanCard.scss
+++ b/src/PortfolioPlanning/Components/Directory/PlanCard.scss
@@ -6,14 +6,14 @@
 }
 
 .plan-card {
-    width: 240px;
+    width: 260px;
     height: 300px;
     background-color: $white;
     @extend .font-weight-semibold;
 
     .name {
         @extend .title-s;
-        height: 32px;
+        height: 40px;
     }
 
     .description {

--- a/src/PortfolioPlanning/Components/Directory/PlanCard.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanCard.tsx
@@ -3,32 +3,32 @@ import { Card } from "azure-devops-ui/Card";
 
 import "./PlanCard.scss";
 
-export interface PlanCardProps {
+export interface IPlanCardProps {
     id: string;
     name: string;
     description: string;
+    teams: string[];
+    projects: string[];
     onClick: (id: string) => void;
 }
 
-export default class PlanCard extends React.Component<PlanCardProps> {
-    public render() {
-        return (
-            <div className="plan-card-container" onClick={() => this.props.onClick(this.props.id)}>
-                <Card className="plan-card">
-                    <div className="flex-column">
-                        <div className="name">{this.props.name}</div>
-                        <div className="description">{this.props.description}</div>
-                        <div className="teams-container">
-                            <div className="teams-label">Teams</div>
-                            <div>TODO</div>
-                        </div>
-                        <div className="projects-container">
-                            <div className="projects-label">Projects</div>
-                            <div>TODO</div>
-                        </div>
+export const PlanCard = (props: IPlanCardProps) => {
+    return (
+        <div className="plan-card-container" onClick={() => props.onClick(props.id)}>
+            <Card className="plan-card">
+                <div className="flex-column">
+                    <div className="name">{props.name}</div>
+                    <div className="description">{props.description}</div>
+                    <div className="teams-container">
+                        <div className="teams-label">Teams</div>
+                        <div>{props.teams.join(", ")}</div>
                     </div>
-                </Card>
-            </div>
-        );
-    }
-}
+                    <div className="projects-container">
+                        <div className="projects-label">Projects</div>
+                        <div>{props.projects.join(", ")}</div>
+                    </div>
+                </div>
+            </Card>
+        </div>
+    );
+};

--- a/src/PortfolioPlanning/Components/Directory/PlanCard.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanCard.tsx
@@ -7,8 +7,8 @@ export interface IPlanCardProps {
     id: string;
     name: string;
     description: string;
-    teams: string[];
     projects: string[];
+    teams: string[];
     onClick: (id: string) => void;
 }
 
@@ -19,14 +19,20 @@ export const PlanCard = (props: IPlanCardProps) => {
                 <div className="flex-column">
                     <div className="name">{props.name}</div>
                     <div className="description">{props.description}</div>
-                    <div className="teams-container">
-                        <div className="teams-label">Teams</div>
-                        <div>{props.teams.join(", ")}</div>
-                    </div>
-                    <div className="projects-container">
-                        <div className="projects-label">Projects</div>
-                        <div>{props.projects.join(", ")}</div>
-                    </div>
+                    {props.projects &&
+                        props.projects.length > 0 && (
+                            <div className="projects-container">
+                                <div className="projects-label">Projects</div>
+                                <div>{props.projects.join(", ")}</div>
+                            </div>
+                        )}
+                    {props.teams &&
+                        props.teams.length > 0 && (
+                            <div className="teams-container">
+                                <div className="teams-label">Teams</div>
+                                <div>{props.teams.join(", ")}</div>
+                            </div>
+                        )}
                 </div>
             </Card>
         </div>

--- a/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
@@ -86,8 +86,8 @@ export class PlanDirectory extends React.Component<IPlanDirectoryProps & IPlanDi
                     id={plan.id}
                     name={plan.name}
                     description={plan.description}
-                    teams={["Contoso", "WIT X"]}
-                    projects={["Fabrikam", "AzureDevOps"]}
+                    teams={plan.teamNames}
+                    projects={plan.projectNames}
                     onClick={id => this.props.toggleSelectedPlanId(id)}
                 />
             ));

--- a/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import "./PlanDirectory.scss";
 import { Page } from "azure-devops-ui/Page";
 import PlanDirectoryHeader from "./PlanDirectoryHeader";
-import PlanCard from "./PlanCard";
+import { PlanCard } from "./PlanCard";
 import NewPlanDialog from "./NewPlanDialog";
 import { PlanDirectoryActions } from "../../Redux/Actions/PlanDirectoryActions";
 import { connect } from "react-redux";
@@ -86,6 +86,8 @@ export class PlanDirectory extends React.Component<IPlanDirectoryProps & IPlanDi
                     id={plan.id}
                     name={plan.name}
                     description={plan.description}
+                    teams={["Contoso", "WIT X"]}
+                    projects={["Fabrikam", "AzureDevOps"]}
                     onClick={id => this.props.toggleSelectedPlanId(id)}
                 />
             ));

--- a/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
+++ b/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
@@ -77,6 +77,8 @@ export interface PortfolioPlanningMetadata {
     id: string;
     name: string;
     description: string;
+    teamNames: string[];
+    projectNames: string[];
     createdOn: Date;
 }
 

--- a/src/PortfolioPlanning/Redux/Actions/PlanDirectoryActions.ts
+++ b/src/PortfolioPlanning/Redux/Actions/PlanDirectoryActions.ts
@@ -5,6 +5,7 @@ export const enum PlanDirectoryActionTypes {
     Initialize = "PlanDirectory/Initialize",
     CreatePlan = "PlanDirectory/CreatePlan",
     DeletePlan = "PlanDirectory/DeletePlan",
+    UpdateProjectsAndTeamsMetadata = "PlanDirectory/UpdateProjectsAndTeamsMetadata",
     ToggleSelectedPlanId = "PlanDirectory/SelectPlan",
     ToggleNewPlanDialogVisible = "PlanDirectory/ToggleNewPlanDialogVisible"
 }
@@ -19,6 +20,8 @@ export const PlanDirectoryActions = {
             description
         }),
     deletePlan: (id: string) => createAction(PlanDirectoryActionTypes.DeletePlan, { id }),
+    updateProjectsAndTeamsMetadata: (id: string, projectNames: string[], teamNames: string[]) =>
+        createAction(PlanDirectoryActionTypes.UpdateProjectsAndTeamsMetadata, { id, projectNames, teamNames }),
     toggleSelectedPlanId: (id: string) =>
         createAction(PlanDirectoryActionTypes.ToggleSelectedPlanId, {
             id

--- a/src/PortfolioPlanning/Redux/Actions/PlanDirectoryActions.ts
+++ b/src/PortfolioPlanning/Redux/Actions/PlanDirectoryActions.ts
@@ -20,8 +20,8 @@ export const PlanDirectoryActions = {
             description
         }),
     deletePlan: (id: string) => createAction(PlanDirectoryActionTypes.DeletePlan, { id }),
-    updateProjectsAndTeamsMetadata: (id: string, projectNames: string[], teamNames: string[]) =>
-        createAction(PlanDirectoryActionTypes.UpdateProjectsAndTeamsMetadata, { id, projectNames, teamNames }),
+    updateProjectsAndTeamsMetadata: (projectNames: string[], teamNames: string[]) =>
+        createAction(PlanDirectoryActionTypes.UpdateProjectsAndTeamsMetadata, { projectNames, teamNames }),
     toggleSelectedPlanId: (id: string) =>
         createAction(PlanDirectoryActionTypes.ToggleSelectedPlanId, {
             id

--- a/src/PortfolioPlanning/Redux/Reducers/PlanDirectoryReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/PlanDirectoryReducer.ts
@@ -41,9 +41,9 @@ export function planDirectoryReducer(state: IPlanDirectoryState, action: PlanDir
                 break;
             }
             case PlanDirectoryActionTypes.UpdateProjectsAndTeamsMetadata: {
-                const { id, projectNames, teamNames } = action.payload;
+                const { projectNames, teamNames } = action.payload;
 
-                const planToUpdate = draft.plans.find(plan => plan.id === id);
+                const planToUpdate = draft.plans.find(plan => plan.id === draft.selectedPlanId);
 
                 planToUpdate.projectNames = projectNames;
                 planToUpdate.teamNames = teamNames;

--- a/src/PortfolioPlanning/Redux/Reducers/PlanDirectoryReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/PlanDirectoryReducer.ts
@@ -22,6 +22,8 @@ export function planDirectoryReducer(state: IPlanDirectoryState, action: PlanDir
                     id: id,
                     name: name,
                     description: description,
+                    projectNames: [],
+                    teamNames: [],
                     createdOn: new Date()
                 });
 
@@ -35,6 +37,16 @@ export function planDirectoryReducer(state: IPlanDirectoryState, action: PlanDir
 
                 // Navigate back to directory page
                 draft.selectedPlanId = undefined;
+
+                break;
+            }
+            case PlanDirectoryActionTypes.UpdateProjectsAndTeamsMetadata: {
+                const { id, projectNames, teamNames } = action.payload;
+
+                const planToUpdate = draft.plans.find(plan => plan.id === id);
+
+                planToUpdate.projectNames = projectNames;
+                planToUpdate.teamNames = teamNames;
 
                 break;
             }

--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -151,15 +151,6 @@ function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActi
     queryResult.mergeStrategy = MergeType.Add;
 
     yield put(EpicTimelineActions.portfolioItemsReceived(queryResult));
-
-    // Update metadata to contain teams and projects for directory
-    const addedProjects = queryResult.projects.projects.map(project => project.ProjectName);
-    const addedTeams = Object.keys(queryResult.teamAreas.teamsInArea)
-        .map(areaId => queryResult.teamAreas.teamsInArea[areaId])
-        .reduce((teamList, allTeamList) => allTeamList.concat(teamList), [])
-        .map(team => team.teamName);
-
-    yield put(PlanDirectoryActions.updateProjectsAndTeamsMetadata(storedPlan.id, addedProjects, addedTeams));
 }
 
 function* onRemoveEpic(action: ActionsOfType<EpicTimelineActions, EpicTimelineActionTypes.RemoveEpic>): SagaIterator {

--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -151,6 +151,15 @@ function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActi
     queryResult.mergeStrategy = MergeType.Add;
 
     yield put(EpicTimelineActions.portfolioItemsReceived(queryResult));
+
+    // Update metadata to contain teams and projects for directory
+    const addedProjects = queryResult.projects.projects.map(project => project.ProjectName);
+    const addedTeams = Object.keys(queryResult.teamAreas.teamsInArea)
+        .map(areaId => queryResult.teamAreas.teamsInArea[areaId])
+        .reduce((teamList, allTeamList) => allTeamList.concat(teamList), [])
+        .map(team => team.teamName);
+
+    yield put(PlanDirectoryActions.updateProjectsAndTeamsMetadata(storedPlan.id, addedProjects, addedTeams));
 }
 
 function* onRemoveEpic(action: ActionsOfType<EpicTimelineActions, EpicTimelineActionTypes.RemoveEpic>): SagaIterator {

--- a/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
@@ -30,23 +30,6 @@ export function* deletePlan(
     yield effects.call([service, service.DeletePortfolioPlan], id);
 }
 
-// export function* updateProjectsAndTeamsMetadata(
-//     action: ActionsOfType<PlanDirectoryActions, PlanDirectoryActionTypes.UpdateProjectsAndTeamsMetadata>
-// ): SagaIterator {
-//     const { id, projectNames, teamNames } = action.payload;
-
-//     const service = PortfolioPlanningDataService.getInstance();
-
-//     const planToUpdate: PortfolioPlanningMetadata = yield effects.call(
-//         [service, service.GetPortfolioPlanDirectoryEntry],
-//         id
-//     );
-//     planToUpdate.projectNames = projectNames;
-//     planToUpdate.teamNames = teamNames;
-
-//     yield effects.call([service, service.UpdatePortfolioPlanDirectoryEntry], planToUpdate);
-// }
-
 export function* updateProjectsAndTeamsMetadata(
     action: ActionsOfType<EpicTimelineActions, EpicTimelineActionTypes.PortfolioItemsReceived>
 ): SagaIterator {

--- a/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
@@ -2,11 +2,12 @@ import { effects, SagaIterator } from "redux-saga";
 import { PortfolioPlanningDataService } from "../../../Services/PortfolioPlanningDataService";
 import { PlanDirectoryActions, PlanDirectoryActionTypes } from "../Actions/PlanDirectoryActions";
 import { ActionsOfType } from "../Helpers";
-import { PortfolioPlanningDirectory } from "../../Models/PortfolioPlanningQueryModels";
+import { PortfolioPlanningDirectory, PortfolioPlanningMetadata } from "../../Models/PortfolioPlanningQueryModels";
 
 export function* planDirectorySaga(): SagaIterator {
     yield effects.call(initializePlanDirectory);
     yield effects.takeEvery(PlanDirectoryActionTypes.DeletePlan, deletePlan);
+    yield effects.takeEvery(PlanDirectoryActionTypes.UpdateProjectsAndTeamsMetadata, updateProjectsAndTeamsMetadata);
 }
 
 export function* initializePlanDirectory(): SagaIterator {
@@ -25,4 +26,21 @@ export function* deletePlan(
     const service = PortfolioPlanningDataService.getInstance();
 
     yield effects.call([service, service.DeletePortfolioPlan], id);
+}
+
+export function* updateProjectsAndTeamsMetadata(
+    action: ActionsOfType<PlanDirectoryActions, PlanDirectoryActionTypes.UpdateProjectsAndTeamsMetadata>
+): SagaIterator {
+    const { id, projectNames, teamNames } = action.payload;
+
+    const service = PortfolioPlanningDataService.getInstance();
+
+    const planToUpdate: PortfolioPlanningMetadata = yield effects.call(
+        [service, service.GetPortfolioPlanDirectoryEntry],
+        id
+    );
+    planToUpdate.projectNames = projectNames;
+    planToUpdate.teamNames = teamNames;
+
+    yield effects.call([service, service.UpdatePortfolioPlanDirectoryEntry], planToUpdate);
 }

--- a/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
@@ -51,8 +51,16 @@ export function* updateProjectsAndTeamsMetadata(
         .reduce((teamList, allTeamList) => allTeamList.concat(teamList), [])
         .map(team => team.teamName);
 
-    planToUpdate.projectNames = addedProjects;
-    planToUpdate.teamNames = addedTeams;
+    addedProjects.forEach(projectName => {
+        if (!planToUpdate.projectNames.find(existingName => existingName === projectName)) {
+            planToUpdate.projectNames.push(projectName);
+        }
+    });
+    addedTeams.forEach(teamName => {
+        if (!planToUpdate.teamNames.find(existingName => existingName === teamName)) {
+            planToUpdate.teamNames.push(teamName);
+        }
+    });
 
     yield effects.call([service, service.UpdatePortfolioPlanDirectoryEntry], planToUpdate);
 

--- a/src/PortfolioPlanning/Redux/Selectors/PlanDirectorySelectors.ts
+++ b/src/PortfolioPlanning/Redux/Selectors/PlanDirectorySelectors.ts
@@ -1,0 +1,5 @@
+import { IPortfolioPlanningState } from "../Contracts";
+
+export function getSelectedPlanId(state: IPortfolioPlanningState): string {
+    return state.planDirectoryState.selectedPlanId;
+}

--- a/src/Services/PortfolioPlanningDataService.ts
+++ b/src/Services/PortfolioPlanningDataService.ts
@@ -14,7 +14,8 @@ import {
     PortfolioPlanningTeamsInAreaQueryInput,
     PortfolioPlanningTeamsInAreaQueryResult,
     TeamsInArea,
-    PortfolioPlanningFullContentQueryResult
+    PortfolioPlanningFullContentQueryResult,
+    PortfolioPlanningMetadata
 } from "../PortfolioPlanning/Models/PortfolioPlanningQueryModels";
 import { ODataClient } from "../Common/OData/ODataClient";
 import { ODataWorkItemQueryResult, ODataAreaQueryResult } from "../PortfolioPlanning/Models/ODataQueryModels";
@@ -181,6 +182,23 @@ export class PortfolioPlanningDataService {
             );
     }
 
+    public async GetPortfolioPlanDirectoryEntry(id: string): Promise<PortfolioPlanningMetadata> {
+        const allPlans = await this.GetAllPortfolioPlans();
+
+        return allPlans.entries.find(plan => plan.id === id);
+    }
+
+    public async UpdatePortfolioPlanDirectoryEntry(updatedPlan: PortfolioPlanningMetadata): Promise<void> {
+        const client = await this.GetStorageClient();
+
+        const allPlans = await this.GetAllPortfolioPlans();
+        let indexToUpdate = allPlans.entries.findIndex(plan => plan.id === updatedPlan.id);
+        updatedPlan.id = allPlans.entries[indexToUpdate].id;
+        allPlans.entries[indexToUpdate] = updatedPlan;
+
+        await client.updateDocument(PortfolioPlanningDataService.DirectoryCollectionName, allPlans);
+    }
+
     private static readonly DirectoryDocumentId: string = "Default";
     private static readonly DirectoryCollectionName: string = "Directory";
     private static readonly PortfolioPlansCollectionName: string = "PortfolioPlans";
@@ -193,6 +211,8 @@ export class PortfolioPlanningDataService {
             id: newPlanId,
             name: newPlanName,
             description: newPlanDescription,
+            teamNames: [],
+            projectNames: [],
             createdOn: new Date(),
             projects: {}
         };


### PR DESCRIPTION
- Storing the projects and teams in the directory metadata
- This info gets updated after the plan loads just in case team or project names have changed
- Adding a work item to the plan updates the metadata

Still need to do the delete scenario but there was no easy way to pass along the project name and team name from the epic id that is passed to the delete. But since the next time the user enters the plan this info gets updated it will be eventually consistent. I'll create a user story to track but it seems low priority.