### PR TITLE
fix add default start and end dates bug.

### DIFF
--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -133,7 +133,7 @@ function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActi
     let now, oneMonthFromNow;
 
     queryResult.items.items.map(item => {
-        if (item.StartDate === undefined || item.TargetDate === undefined) {
+        if (!item.StartDate || !item.TargetDate) {
             now = new Date();
             oneMonthFromNow = new Date();
             oneMonthFromNow.setDate(now.getDate() + 30);


### PR DESCRIPTION
Seems like we have changed item start date and end date to null rather than undefined, when they are not set.

Because of this we can't ad epic to timeline since default dates are not set.