### PR TITLE
Show error messages

### DIFF
--- a/src/PortfolioPlanning/Common/ODataClient.ts
+++ b/src/PortfolioPlanning/Common/ODataClient.ts
@@ -41,7 +41,7 @@ export class ODataClient {
 
         if (
             collectionUri.toLowerCase().indexOf("localhost") !== -1 ||
-            collectionUri.toLowerCase().indexOf("DefaultCollection") !== -1
+            collectionUri.toLowerCase().indexOf("defaultcollection") !== -1
         ) {
             //  Hack to construct OData endpoint based on deployment type (hosted vs onprem).
             return `${collectionUri}${projectSegment}_odata/${ODataClient.oDataVersion}/`;

--- a/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
+++ b/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
@@ -422,9 +422,10 @@ export class PortfolioPlanningDataService {
             return null;
         }
 
+        const responseString: string = results;
+
         try {
             //  TODO hack hack ... Look for start of JSON response "{"@odata.context""
-            const responseString: string = results;
             const start = responseString.indexOf('{"@odata.context"');
             const end = responseString.lastIndexOf("}");
             const jsonString = responseString.substring(start, end + 1);
@@ -441,8 +442,13 @@ export class PortfolioPlanningDataService {
         } catch (error) {
             console.log(error);
 
+            const start = responseString.indexOf('{"error"');
+            const end = responseString.lastIndexOf("}");
+            const jsonString = responseString.substring(start, end + 1);
+            const jsonObject = JSON.parse(jsonString);
+
             return {
-                exceptionMessage: "Could not retrieve work item data.",
+                exceptionMessage: jsonObject.error.message,
                 items: []
             };
         }

--- a/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
+++ b/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
@@ -429,7 +429,7 @@ export class PortfolioPlanningDataService {
             const start = responseString.indexOf('{"@odata.context"');
             const end = responseString.lastIndexOf("}");
 
-            if (start != -1) {
+            if (start !== -1) {
                 const jsonString = responseString.substring(start, end + 1);
                 const jsonObject = JSON.parse(jsonString);
 

--- a/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
+++ b/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
@@ -428,27 +428,35 @@ export class PortfolioPlanningDataService {
             //  TODO hack hack ... Look for start of JSON response "{"@odata.context""
             const start = responseString.indexOf('{"@odata.context"');
             const end = responseString.lastIndexOf("}");
-            const jsonString = responseString.substring(start, end + 1);
-            const jsonObject = JSON.parse(jsonString);
 
-            if (!jsonObject || !jsonObject["value"]) {
-                return null;
+            if (start != -1) {
+                const jsonString = responseString.substring(start, end + 1);
+                const jsonObject = JSON.parse(jsonString);
+
+                if (!jsonObject || !jsonObject["value"]) {
+                    return null;
+                }
+
+                return {
+                    exceptionMessage: null,
+                    items: this.PortfolioPlanningQueryResultItems(jsonObject.value, aggregationClauses)
+                };
+            } else {
+                const start = responseString.indexOf('{"error"');
+                const end = responseString.lastIndexOf("}");
+                const jsonString = responseString.substring(start, end + 1);
+                const jsonObject = JSON.parse(jsonString);
+
+                return {
+                    exceptionMessage: jsonObject.error.message,
+                    items: []
+                };
             }
-
-            return {
-                exceptionMessage: null,
-                items: this.PortfolioPlanningQueryResultItems(jsonObject.value, aggregationClauses)
-            };
         } catch (error) {
             console.log(error);
 
-            const start = responseString.indexOf('{"error"');
-            const end = responseString.lastIndexOf("}");
-            const jsonString = responseString.substring(start, end + 1);
-            const jsonObject = JSON.parse(jsonString);
-
             return {
-                exceptionMessage: jsonObject.error.message,
+                exceptionMessage: error.message,
                 items: []
             };
         }

--- a/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
+++ b/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
@@ -456,7 +456,7 @@ export class PortfolioPlanningDataService {
             console.log(error);
 
             return {
-                exceptionMessage: error.message,
+                exceptionMessage: error,
                 items: []
             };
         }

--- a/src/PortfolioPlanning/Components/Plan/PlanHeader.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanHeader.tsx
@@ -7,6 +7,7 @@ export interface PlanHeaderProps {
     name: string;
     description: string;
     itemIsSelected: boolean;
+    disabled: boolean;
     onBackButtonClicked: () => void;
     onAddItemClicked: () => void;
     onRemoveSelectedItemClicked: () => void;
@@ -31,6 +32,7 @@ export default class PlanHeader extends React.Component<PlanHeaderProps> {
                             },
                             important: true,
                             subtle: true,
+                            disabled: this.props.disabled,
                             onActivate: () => {
                                 this.props.onAddItemClicked();
                             }
@@ -42,6 +44,7 @@ export default class PlanHeader extends React.Component<PlanHeaderProps> {
                             },
                             important: true,
                             subtle: true,
+                            disabled: this.props.disabled,
                             onActivate: () => {
                                 this.props.onSettingsButtonClicked();
                             }
@@ -54,7 +57,7 @@ export default class PlanHeader extends React.Component<PlanHeaderProps> {
                             text: "Remove selected epic",
                             important: false,
                             subtle: true,
-                            disabled: !this.props.itemIsSelected,
+                            disabled: this.props.disabled || !this.props.itemIsSelected,
                             onActivate: () => {
                                 this.props.onRemoveSelectedItemClicked();
                             }

--- a/src/PortfolioPlanning/Components/Plan/PlanPage.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.scss
@@ -4,6 +4,16 @@
     position: absolute;
     width: 100%;
     height: 100%;
+
+    .plan-content {
+        width: 100%;
+        height: 100%;
+    }
+
+    .plan-spinner {
+        width: 100%;
+        height: 100%;
+    }
 }
 
 .bolt-button.bolt-header-back-button {

--- a/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
@@ -65,7 +65,12 @@ export default class PlanPage extends React.Component<IPlanPageProps, IPortfolio
         if (this.props.planLoadingStatus === LoadingStatus.NotLoaded) {
             planContent = <Spinner className="plan-spinner" label="Loading..." size={SpinnerSize.large} />;
         } else if (this.props.exceptionMessage) {
-            planContent = <div>{this.props.exceptionMessage}</div>;
+            let errorMessage = this.props.exceptionMessage;
+            if (this.props.exceptionMessage.includes("VS403496")) {
+                errorMessage =
+                    "This plan includes projects that you do not have access to. Update your permissions to view this plan. More information can be found here: https://go.microsoft.com/fwlink/?LinkId=786441.";
+            }
+            planContent = <div>{errorMessage}</div>;
         } else {
             planContent = (
                 <>

--- a/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
@@ -49,20 +49,26 @@ export default class PlanPage extends React.Component<IPlanPageProps, IPortfolio
                     onBackButtonClicked={this._backButtonClicked}
                     onSettingsButtonClicked={this._settingsButtonClicked}
                 />
-                <div className="page-content page-content-top">
-                    <PlanSummary
-                        projectNames={this.props.projectNames}
-                        teamNames={this.props.teamNames}
-                        owner={this.props.plan.owner}
-                    />
-                    <ConnectedPlanTimeline />
-                </div>
+                {this._renderPlanContent()}
                 {this._renderAddItemPanel()}
                 {this._renderItemDetailsDialog()}
                 {this._renderPlanSettingsPanel()}
             </Page>
         );
     }
+
+    private _renderPlanContent = (): JSX.Element => {
+        return (
+            <div className="page-content page-content-top">
+                <PlanSummary
+                    projectNames={this.props.projectNames}
+                    teamNames={this.props.teamNames}
+                    owner={this.props.plan.owner}
+                />
+                <ConnectedPlanTimeline />
+            </div>
+        );
+    };
 
     private _renderAddItemPanel = (): JSX.Element => {
         if (this.props.addItemPanelOpen) {

--- a/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
@@ -25,6 +25,7 @@ interface IPlanPageMappedProps {
     addItemPanelOpen: boolean;
     setDatesDialogHidden: boolean;
     planSettingsPanelOpen: boolean;
+    exceptionMessage: string;
 }
 
 export type IPlanPageProps = IPlanPageMappedProps & typeof Actions;
@@ -41,6 +42,7 @@ export default class PlanPage extends React.Component<IPlanPageProps, IPortfolio
                     id={this.props.plan.id}
                     name={this.props.plan.name}
                     description={this.props.plan.description}
+                    disabled={!!this.props.exceptionMessage}
                     itemIsSelected={!!this.props.selectedItem}
                     onAddItemClicked={this.props.onOpenAddItemPanel}
                     onRemoveSelectedItemClicked={this._onRemoveSelectedEpicClick}
@@ -154,7 +156,8 @@ function mapStateToProps(state: IPortfolioPlanningState): IPlanPageMappedProps {
         progressTrackingCriteria: state.epicTimelineState.progressTrackingCriteria,
         addItemPanelOpen: state.epicTimelineState.addEpicDialogOpen,
         setDatesDialogHidden: state.epicTimelineState.setDatesDialogHidden,
-        planSettingsPanelOpen: state.epicTimelineState.planSettingsPanelOpen
+        planSettingsPanelOpen: state.epicTimelineState.planSettingsPanelOpen,
+        exceptionMessage: state.epicTimelineState.exceptionMessage
     };
 }
 

--- a/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
@@ -16,6 +16,7 @@ import { ProgressTrackingCriteria, ITimelineItem, LoadingStatus } from "../../Co
 import { AddItemPanel } from "./AddItemPanel";
 import { DetailsDialog } from "./DetailsDialog";
 import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
+import { Link } from "azure-devops-ui/Link";
 
 interface IPlanPageMappedProps {
     plan: PortfolioPlanningMetadata;
@@ -67,10 +68,20 @@ export default class PlanPage extends React.Component<IPlanPageProps, IPortfolio
         } else if (this.props.exceptionMessage) {
             let errorMessage = this.props.exceptionMessage;
             if (this.props.exceptionMessage.includes("VS403496")) {
+                const helpLink = "https://go.microsoft.com/fwlink/?LinkId=786441";
                 errorMessage =
-                    "This plan includes projects that you do not have access to. Update your permissions to view this plan. More information can be found here: https://go.microsoft.com/fwlink/?LinkId=786441.";
+                    "This plan includes projects that you do not have access to. Update your permissions to view this plan. More information can be found here: ";
+                planContent = (
+                    <div>
+                        {errorMessage}
+                        <Link href={helpLink} target="_blank">
+                            {helpLink}
+                        </Link>
+                    </div>
+                );
+            } else {
+                planContent = <div>{errorMessage}</div>;
             }
-            planContent = <div>{errorMessage}</div>;
         } else {
             planContent = (
                 <>

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -26,6 +26,7 @@ interface IPlanTimelineMappedProps {
     planOwner: IdentityRef;
     visibleTimeStart: number;
     visibleTimeEnd: number;
+    exceptionMessage: string;
 }
 
 export type IPlanTimelineProps = IPlanTimelineMappedProps & typeof Actions;
@@ -39,6 +40,10 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
         if (this.props.planLoadingStatus === LoadingStatus.NotLoaded) {
             return <Spinner label="Loading..." size={SpinnerSize.large} />;
         } else {
+            if (this.props.exceptionMessage) {
+                return <div>{this.props.exceptionMessage}</div>;
+            }
+
             const [defaultTimeStart, defaultTimeEnd] = this._getDefaultTimes(this.props.items);
 
             const forwardCircleStyle = {
@@ -194,7 +199,8 @@ function mapStateToProps(state: IPortfolioPlanningState): IPlanTimelineMappedPro
         planOwner: getSelectedPlanOwner(state),
         planLoadingStatus: state.epicTimelineState.planLoadingStatus,
         visibleTimeStart: state.epicTimelineState.visibleTimeStart,
-        visibleTimeEnd: state.epicTimelineState.visibleTimeEnd
+        visibleTimeEnd: state.epicTimelineState.visibleTimeEnd,
+        exceptionMessage: state.epicTimelineState.exceptionMessage
     };
 }
 

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as moment from "moment";
-import { ITimelineGroup, ITimelineItem, ITeam, LoadingStatus } from "../../Contracts";
+import { ITimelineGroup, ITimelineItem, ITeam } from "../../Contracts";
 import Timeline from "react-calendar-timeline";
 import "./PlanTimeline.scss";
 import { IPortfolioPlanningState } from "../../Redux/Contracts";
@@ -9,7 +9,6 @@ import { EpicTimelineActions } from "../../Redux/Actions/EpicTimelineActions";
 import { connect } from "react-redux";
 import { ProgressDetails } from "../../Common/Components/ProgressDetails";
 import { InfoIcon } from "../../Common/Components/InfoIcon";
-import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
 import { getSelectedPlanOwner } from "../../Redux/Selectors/PlanDirectorySelectors";
 import { IdentityRef } from "VSS/WebApi/Contracts";
 
@@ -22,7 +21,6 @@ interface IPlanTimelineMappedProps {
     teams: { [teamId: string]: ITeam };
     items: ITimelineItem[];
     selectedItemId: number;
-    planLoadingStatus: LoadingStatus;
     planOwner: IdentityRef;
     visibleTimeStart: number;
     visibleTimeEnd: number;
@@ -37,83 +35,75 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
     }
 
     public render(): JSX.Element {
-        if (this.props.planLoadingStatus === LoadingStatus.NotLoaded) {
-            return <Spinner label="Loading..." size={SpinnerSize.large} />;
-        } else {
-            if (this.props.exceptionMessage) {
-                return <div>{this.props.exceptionMessage}</div>;
-            }
+        const [defaultTimeStart, defaultTimeEnd] = this._getDefaultTimes(this.props.items);
 
-            const [defaultTimeStart, defaultTimeEnd] = this._getDefaultTimes(this.props.items);
+        const forwardCircleStyle = {
+            padding: "0px 0px 0px 10px"
+        };
 
-            const forwardCircleStyle = {
-                padding: "0px 0px 0px 10px"
-            };
-
-            return (
-                <Timeline
-                    groups={this.props.groups}
-                    items={this.props.items}
-                    visibleTimeStart={this.props.visibleTimeStart || defaultTimeStart}
-                    visibleTimeEnd={this.props.visibleTimeEnd || defaultTimeEnd}
-                    onTimeChange={this._handleTimeChange}
-                    canChangeGroup={false}
-                    stackItems={true}
-                    dragSnap={day}
-                    minZoom={week}
-                    canResize={"both"}
-                    minResizeWidth={50}
-                    onItemResize={this._onItemResize}
-                    onItemMove={this._onItemMove}
-                    moveResizeValidator={this._validateResize}
-                    selecte={[this.props.selectedItemId]}
-                    onItemSelect={itemId => this.props.onSetSelectedItemId(itemId)}
-                    onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
-                    itemRenderer={({ item, itemContext, getItemProps }) => {
-                        return (
-                            <div {...getItemProps(item.itemProps)}>
+        return (
+            <Timeline
+                groups={this.props.groups}
+                items={this.props.items}
+                visibleTimeStart={this.props.visibleTimeStart || defaultTimeStart}
+                visibleTimeEnd={this.props.visibleTimeEnd || defaultTimeEnd}
+                onTimeChange={this._handleTimeChange}
+                canChangeGroup={false}
+                stackItems={true}
+                dragSnap={day}
+                minZoom={week}
+                canResize={"both"}
+                minResizeWidth={50}
+                onItemResize={this._onItemResize}
+                onItemMove={this._onItemMove}
+                moveResizeValidator={this._validateResize}
+                selecte={[this.props.selectedItemId]}
+                onItemSelect={itemId => this.props.onSetSelectedItemId(itemId)}
+                onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
+                itemRenderer={({ item, itemContext, getItemProps }) => {
+                    return (
+                        <div {...getItemProps(item.itemProps)}>
+                            <div
+                                style={{
+                                    maxHeight: `${itemContext.dimensions.height}`,
+                                    display: "flex",
+                                    justifyContent: "space-between",
+                                    overflow: "hidden",
+                                    marginRight: "5px",
+                                    alignItems: "baseline",
+                                    whiteSpace: "nowrap"
+                                }}
+                            >
+                                {itemContext.title}
                                 <div
                                     style={{
-                                        maxHeight: `${itemContext.dimensions.height}`,
                                         display: "flex",
-                                        justifyContent: "space-between",
-                                        overflow: "hidden",
-                                        marginRight: "5px",
-                                        alignItems: "baseline",
-                                        whiteSpace: "nowrap"
+                                        justifyContent: "flex-end"
                                     }}
                                 >
-                                    {itemContext.title}
+                                    <InfoIcon
+                                        id={item.id}
+                                        onClick={() => this.props.onToggleSetDatesDialogHidden(false)}
+                                    />
+                                    <ProgressDetails
+                                        completed={item.itemProps.completed}
+                                        total={item.itemProps.total}
+                                        onClick={() => {}}
+                                    />
                                     <div
-                                        style={{
-                                            display: "flex",
-                                            justifyContent: "flex-end"
-                                        }}
+                                        className="bowtie-icon bowtie-navigate-forward-circle"
+                                        style={forwardCircleStyle}
+                                        onClick={() => this.navigateToEpicRoadmap(item)}
                                     >
-                                        <InfoIcon
-                                            id={item.id}
-                                            onClick={() => this.props.onToggleSetDatesDialogHidden(false)}
-                                        />
-                                        <ProgressDetails
-                                            completed={item.itemProps.completed}
-                                            total={item.itemProps.total}
-                                            onClick={() => {}}
-                                        />
-                                        <div
-                                            className="bowtie-icon bowtie-navigate-forward-circle"
-                                            style={forwardCircleStyle}
-                                            onClick={() => this.navigateToEpicRoadmap(item)}
-                                        >
-                                            &nbsp;
-                                        </div>
+                                        &nbsp;
                                     </div>
                                 </div>
                             </div>
-                        );
-                    }}
-                />
-            );
-        }
+                        </div>
+                    );
+                }}
+            />
+        );
     }
 
     // Update the visibleTimeStart and visibleTimeEnd when user scroll or zoom the timeline.
@@ -197,7 +187,6 @@ function mapStateToProps(state: IPortfolioPlanningState): IPlanTimelineMappedPro
         items: getTimelineItems(state.epicTimelineState),
         selectedItemId: state.epicTimelineState.selectedItemId,
         planOwner: getSelectedPlanOwner(state),
-        planLoadingStatus: state.epicTimelineState.planLoadingStatus,
         visibleTimeStart: state.epicTimelineState.visibleTimeStart,
         visibleTimeEnd: state.epicTimelineState.visibleTimeEnd,
         exceptionMessage: state.epicTimelineState.exceptionMessage

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -58,7 +58,10 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 break;
             }
             case EpicTimelineActionTypes.PortfolioItemsReceived:
+                const { items } = action.payload;
+
                 draft.planLoadingStatus = LoadingStatus.Loaded;
+                draft.exceptionMessage = items.exceptionMessage;
 
                 return handlePortfolioItemsReceived(draft, action as PortfolioItemsReceivedAction);
 
@@ -130,7 +133,7 @@ export function getDefaultState(): IEpicTimelineState {
         selectedItemId: null,
         progressTrackingCriteria: ProgressTrackingCriteria.CompletedCount,
         visibleTimeStart: null,
-        visibleTimeEnd: null,
+        visibleTimeEnd: null
     };
 }
 
@@ -140,8 +143,6 @@ function handlePortfolioItemsReceived(
 ): IEpicTimelineState {
     return produce(state, draft => {
         const { items, projects, teamAreas, mergeStrategy } = action.payload;
-
-        //  TODO    Handle exception message from OData query results.
 
         if (mergeStrategy === MergeType.Replace) {
             draft.projects = projects.projects.map(project => {
@@ -264,11 +265,15 @@ function handlePortfolioItemsReceived(
                     // Add auto scroll to put newly added epic in view.
                     const newItemStartDate: number = moment(newItemInfo.StartDate).valueOf();
                     const newItemTargetDate: number = moment(newItemInfo.TargetDate).valueOf();
-                    if(newItemStartDate < draft.visibleTimeStart) {
-                        draft.visibleTimeStart = moment(newItemStartDate).add(-1, "months").valueOf();
+                    if (newItemStartDate < draft.visibleTimeStart) {
+                        draft.visibleTimeStart = moment(newItemStartDate)
+                            .add(-1, "months")
+                            .valueOf();
                     }
-                    if(newItemTargetDate > draft.visibleTimeEnd) {
-                        draft.visibleTimeEnd = moment(newItemTargetDate).add(1, "months").valueOf();;
+                    if (newItemTargetDate > draft.visibleTimeEnd) {
+                        draft.visibleTimeEnd = moment(newItemTargetDate)
+                            .add(1, "months")
+                            .valueOf();
                     }
                 }
             });

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -58,10 +58,10 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 break;
             }
             case EpicTimelineActionTypes.PortfolioItemsReceived:
-                const { items } = action.payload;
+                const { items, projects } = action.payload;
 
                 draft.planLoadingStatus = LoadingStatus.Loaded;
-                draft.exceptionMessage = items.exceptionMessage;
+                draft.exceptionMessage = items.exceptionMessage || projects.exceptionMessage;
 
                 return handlePortfolioItemsReceived(draft, action as PortfolioItemsReceivedAction);
 

--- a/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
+++ b/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
@@ -102,3 +102,7 @@ export function getAddEpicPanelOpen(state: IEpicTimelineState): boolean {
 export function getProgressTrackingCriteria(state: IEpicTimelineState): ProgressTrackingCriteria {
     return state.progressTrackingCriteria;
 }
+
+export function getExceptionMessage(state: IPortfolioPlanningState): string {
+    return state.epicTimelineState.exceptionMessage;
+}


### PR DESCRIPTION
- Fixed the parsing logic on odata response.
- Show a simpler error message if it's an analytics permissions issue.
- Show full error if parse still fails.
- Moved loading spinner to plan page rather than the timeline.
- Disable actions on the header if there was an error loading the plan.