### PR TITLE
Allow delete on error

### DIFF
--- a/src/PortfolioPlanning/Components/Plan/AddItemPanel.tsx
+++ b/src/PortfolioPlanning/Components/Plan/AddItemPanel.tsx
@@ -83,7 +83,7 @@ export class AddItemPanel extends React.Component<IAddItemPanelProps, IAddItemPa
         return (
             <Dropdown
                 className="project-picker"
-                placeholder="Select an option"
+                placeholder="Select a project"
                 width={200}
                 items={this.state.projects}
                 onSelect={this.onSelect}

--- a/src/PortfolioPlanning/Components/Plan/PlanHeader.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanHeader.tsx
@@ -44,7 +44,6 @@ export default class PlanHeader extends React.Component<PlanHeaderProps> {
                             },
                             important: true,
                             subtle: true,
-                            disabled: this.props.disabled,
                             onActivate: () => {
                                 this.props.onSettingsButtonClicked();
                             }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,10 +1,10 @@
 {
     "manifestVersion": 1,
     "id": "workitem-portfolio-planning-extension",
-    "version": "0.0.2",
+    "version": "0.0.4",
     "name": "Portfolio Plans",
     "description": "Portfolio level plans across projects and teams.",
-    "publisher": "ms-devlabs",
+    "publisher": "sthutchi",
     "targets": [
         {
             "id": "Microsoft.VisualStudio.Services.Cloud"
@@ -34,7 +34,7 @@
             "addressable": true
         }
     ],
-    "categories": ["Plan and track"],
+    "categories": ["Azure Boards"],
     "contributions": [
         {
             "id": "workitem-portfolio-planning",


### PR DESCRIPTION
This is just a small change so that we can publish the permissions error changes to beta users.

* Changed the project picker message
* Allow a plan to be deleted if there is an error loading
* Update publisher

