### PR TITLE
Style timeline

### DIFF
--- a/src/PortfolioPlanning/Common/Components/InfoIcon.scss
+++ b/src/PortfolioPlanning/Common/Components/InfoIcon.scss
@@ -1,5 +1,4 @@
 .info-icon {
-    margin-left: 5px;
     cursor: pointer;
     display: flex;
     align-items: center;

--- a/src/PortfolioPlanning/Common/Components/InfoIcon.scss
+++ b/src/PortfolioPlanning/Common/Components/InfoIcon.scss
@@ -3,5 +3,4 @@
     cursor: pointer;
     display: flex;
     align-items: center;
-    // color: grey !important;
 }

--- a/src/PortfolioPlanning/Common/Components/InfoIcon.scss
+++ b/src/PortfolioPlanning/Common/Components/InfoIcon.scss
@@ -1,11 +1,7 @@
 .info-icon {
     margin-left: 5px;
-    color: transparent !important;
     cursor: pointer;
     display: flex;
     align-items: center;
-}
-
-.info-icon:hover {
-    color: grey !important;
+    // color: grey !important;
 }

--- a/src/PortfolioPlanning/Common/Components/InfoIcon.tsx
+++ b/src/PortfolioPlanning/Common/Components/InfoIcon.tsx
@@ -2,6 +2,7 @@ import "./InfoIcon.scss";
 import * as React from "react";
 
 export interface IInfoIconProps {
+    className?: string;
     id: number;
     onClick: (id: number) => void;
 }
@@ -9,7 +10,10 @@ export interface IInfoIconProps {
 export class InfoIcon extends React.Component<IInfoIconProps, {}> {
     public render() {
         return (
-            <div className="bowtie-icon bowtie-status-info info-icon" onClick={() => this.props.onClick(this.props.id)}>
+            <div
+                className={"bowtie-icon bowtie-status-info info-icon " + this.props.className}
+                onClick={() => this.props.onClick(this.props.id)}
+            >
                 &nbsp;
             </div>
         );

--- a/src/PortfolioPlanning/Common/Components/ProgressDetails.scss
+++ b/src/PortfolioPlanning/Common/Components/ProgressDetails.scss
@@ -2,7 +2,7 @@
     display: flex;
     align-items: center;
     cursor: pointer;
-    margin-left: 10px;   
+    margin-right: 10px;
 }
 
 .progress-indicator-tooltip {

--- a/src/PortfolioPlanning/Common/Components/ProgressDetails.tsx
+++ b/src/PortfolioPlanning/Common/Components/ProgressDetails.tsx
@@ -11,10 +11,7 @@ export interface IProgressIndicatorProps extends IProgressIndicator {
     onClick: () => void;
 }
 
-export class ProgressDetails extends React.Component<
-    IProgressIndicatorProps,
-    {}
-> {
+export class ProgressDetails extends React.Component<IProgressIndicatorProps, {}> {
     public render() {
         const { total, completed, onClick } = this.props;
 
@@ -26,10 +23,7 @@ export class ProgressDetails extends React.Component<
         style["width"] = `${(completed * 100) / total}%`;
         const progressText = `${completed}/${total}`;
         return (
-            <TooltipHost
-                content={progressText}
-                className="progress-indicator-tooltip"
-            >
+            <TooltipHost content={progressText} className="progress-indicator-tooltip">
                 <div className="progress-indicator-container" onClick={onClick}>
                     <div className="progress-details-parts">
                         <div className="progress-completed" style={style} />

--- a/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
@@ -95,7 +95,7 @@ export default class PlanPage extends React.Component<IPlanPageProps, IPortfolio
             );
         }
 
-        return <div className="page-content page-content-top plan-content">{planContent}</div>;
+        return <div className="plan-content">{planContent}</div>;
     };
 
     private _renderAddItemPanel = (): JSX.Element => {

--- a/src/PortfolioPlanning/Components/Plan/PlanSummary.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanSummary.tsx
@@ -14,7 +14,7 @@ export const PlanSummary = (props: IPlanSummaryProps) => {
     const teamNameList = props.teamNames.join(", ");
 
     return (
-        <div className="plan-summary">
+        <div className="page-content page-content-top plan-summary">
             <IdentityView className="owner" value={props.owner} />
             {projectNameList && (
                 <div className="summary-item">

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
@@ -11,7 +11,7 @@
 }
 
 .plan-timeline-group {
-    @extend .title-s;
+    @extend .title-xs;
 
     height: 100%;
     display: flex;
@@ -62,7 +62,7 @@
     vertical-align: top;
     position: relative;
     box-sizing: border-box;
-    border-right: 1px solid #bbb;
+    // border-right: 1px solid #bbb;
 }
 .react-calendar-timeline .rct-sidebar.rct-sidebar-right {
     border-right: 0;
@@ -78,10 +78,10 @@
     border-bottom: 1px solid #bbb;
 }
 .react-calendar-timeline .rct-sidebar .rct-sidebar-row.rct-sidebar-row-odd {
-    background: rgba(0, 0, 0, 0.05);
+    // background: rgba(0, 0, 0, 0.05);
 }
 .react-calendar-timeline .rct-sidebar .rct-sidebar-row.rct-sidebar-row-even {
-    background: transparent;
+    // background: transparent;
 }
 
 .react-calendar-timeline .rct-vertical-lines .rct-vl {
@@ -90,7 +90,7 @@
     z-index: 30;
 }
 .react-calendar-timeline .rct-vertical-lines .rct-vl.rct-vl-first {
-    border-left-width: 2px;
+    // border-left-width: 2px;
 }
 .react-calendar-timeline .rct-vertical-lines .rct-vl.rct-day-6,
 .react-calendar-timeline .rct-vertical-lines .rct-vl.rct-day-0 {
@@ -105,11 +105,11 @@
 }
 
 .react-calendar-timeline .rct-horizontal-lines .rct-hl-odd {
-    background: rgba(0, 0, 0, 0.05);
+    // background: rgba(0, 0, 0, 0.05);
 }
 
 .react-calendar-timeline .rct-horizontal-lines .rct-hl-even {
-    background: transparent;
+    // background: transparent;
 }
 
 .react-calendar-timeline .rct-cursor-line {
@@ -136,27 +136,33 @@
     align-items: center;
     justify-content: center;
     height: 100%;
-    border-bottom: 1px solid #bbb;
+    // border-bottom: 1px solid #bbb;
     cursor: pointer;
-    font-size: 14px;
-    background-color: #f0f0f0;
-    border-left: 2px solid #bbb;
+    // font-size: 14px;
+    // background-color: #f0f0f0;
+    // border-left: 2px solid transparent;
+
+    @extend .font-weight-semibold;
+    color: $secondary-text;
+    border-right: 1px solid #bbb;
 }
 
 .react-calendar-timeline .rct-dateHeader-primary {
-    background-color: initial;
-    border-left: 1px solid #bbb;
-    border-right: 1px solid #bbb;
-    color: #fff;
+    // background-color: initial;
+    // border-left: 1px solid #bbb;
+    // border-right: 1px solid #bbb;
+    // color: #fff;
+
+    // display: none;
 }
 
 .react-calendar-timeline .rct-header-root {
-    background: #c52020;
+    // background: #c52020;
     border-bottom: 1px solid #bbb;
 }
 
 .react-calendar-timeline .rct-calendar-header {
-    border: 1px solid #bbb;
+    // border: 1px solid #bbb;
 }
 
 // End copy from react-calendar-timeline //

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
@@ -20,14 +20,20 @@
 }
 
 .plan-timeline-item {
-    display: flex;
-    justify-content: space-between;
-    overflow: hidden;
-    align-items: baseline;
-    white-space: nowrap;
-
     @extend .depth-8;
-    border: none;
+    @extend .font-weight-semibold;
+
+    .details {
+        display: flex;
+        justify-content: space-between;
+        overflow: hidden;
+        align-items: baseline;
+        white-space: nowrap;
+
+        .title {
+            margin-left: $spacing-8;
+        }
+    }
 }
 
 // Copied from react-calendar-timeline //

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
@@ -3,6 +3,9 @@
 
 .plan-timeline-container {
     margin-top: $spacing-16;
+    height: 100%;
+
+    background-color: $neutral-2;
 }
 
 // Copied from react-calendar-timeline //

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
@@ -38,13 +38,19 @@
             color: $communication-foreground;
         }
 
-        .to-epic-roadmap {
-            color: $communication-foreground;
+        .progress-indicator {
+            padding-right: $spacing-4;
         }
     }
 
     &:hover .show-on-hover {
         display: inherit;
+    }
+
+    .to-epic-roadmap {
+        color: $communication-foreground;
+        display: flex;
+        align-items: center;
     }
 
     .show-on-hover {

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
@@ -10,6 +10,15 @@
     padding-right: $spacing-32;
 }
 
+.plan-timeline-group {
+    @extend .title-s;
+
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 // Copied from react-calendar-timeline //
 .react-calendar-timeline * {
     box-sizing: border-box;

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
@@ -33,6 +33,22 @@
         .title {
             margin-left: $spacing-8;
         }
+
+        .info-icon {
+            color: $communication-foreground;
+        }
+
+        .to-epic-roadmap {
+            color: $communication-foreground;
+        }
+    }
+
+    &:hover .show-on-hover {
+        display: inherit;
+    }
+
+    .show-on-hover {
+        display: none;
     }
 }
 

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
@@ -1,3 +1,10 @@
+@import "node_modules/azure-devops-ui/Core/_platformCommon.scss";
+@import "node_modules/azure-devops-ui/Core/core.scss";
+
+.plan-timeline-container {
+    margin-top: $spacing-16;
+}
+
 // Copied from react-calendar-timeline //
 .react-calendar-timeline * {
     box-sizing: border-box;

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
@@ -6,6 +6,8 @@
     height: 100%;
 
     background-color: $neutral-2;
+    padding-left: $spacing-32;
+    padding-right: $spacing-32;
 }
 
 // Copied from react-calendar-timeline //

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
@@ -19,6 +19,17 @@
     justify-content: center;
 }
 
+.plan-timeline-item {
+    display: flex;
+    justify-content: space-between;
+    overflow: hidden;
+    align-items: baseline;
+    white-space: nowrap;
+
+    @extend .depth-8;
+    border: none;
+}
+
 // Copied from react-calendar-timeline //
 .react-calendar-timeline * {
     box-sizing: border-box;

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -72,14 +72,10 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
     }
 
     private _renderItem = (item, itemContext, getItemProps) => {
-        const forwardCircleStyle = {
-            padding: "0px 0px 0px 10px"
-        };
-
         let borderStyle = {};
         if (itemContext.selected) {
             borderStyle = {
-                borderWidth: "1px",
+                borderWidth: "2px",
                 borderStyle: "solid",
                 borderColor: "#106ebe"
             };
@@ -108,19 +104,18 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
                             justifyContent: "flex-end"
                         }}
                     >
-                        <InfoIcon
-                            className="show-on-hover"
-                            id={item.id}
-                            onClick={() => this.props.onToggleSetDatesDialogHidden(false)}
-                        />
                         <ProgressDetails
                             completed={item.itemProps.completed}
                             total={item.itemProps.total}
                             onClick={() => {}}
                         />
+                        <InfoIcon
+                            className="show-on-hover"
+                            id={item.id}
+                            onClick={() => this.props.onToggleSetDatesDialogHidden(false)}
+                        />
                         <div
                             className="bowtie-icon bowtie-navigate-forward-circle show-on-hover to-epic-roadmap"
-                            style={forwardCircleStyle}
                             onClick={() => this.navigateToEpicRoadmap(item)}
                         >
                             &nbsp;

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -42,67 +42,69 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
         };
 
         return (
-            <Timeline
-                groups={this.props.groups}
-                items={this.props.items}
-                visibleTimeStart={this.props.visibleTimeStart || defaultTimeStart}
-                visibleTimeEnd={this.props.visibleTimeEnd || defaultTimeEnd}
-                onTimeChange={this._handleTimeChange}
-                canChangeGroup={false}
-                stackItems={true}
-                dragSnap={day}
-                minZoom={week}
-                canResize={"both"}
-                minResizeWidth={50}
-                onItemResize={this._onItemResize}
-                onItemMove={this._onItemMove}
-                moveResizeValidator={this._validateResize}
-                selecte={[this.props.selectedItemId]}
-                onItemSelect={itemId => this.props.onSetSelectedItemId(itemId)}
-                onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
-                itemRenderer={({ item, itemContext, getItemProps }) => {
-                    return (
-                        <div {...getItemProps(item.itemProps)}>
-                            <div
-                                style={{
-                                    maxHeight: `${itemContext.dimensions.height}`,
-                                    display: "flex",
-                                    justifyContent: "space-between",
-                                    overflow: "hidden",
-                                    marginRight: "5px",
-                                    alignItems: "baseline",
-                                    whiteSpace: "nowrap"
-                                }}
-                            >
-                                {itemContext.title}
+            <div className="plan-timeline-container">
+                <Timeline
+                    groups={this.props.groups}
+                    items={this.props.items}
+                    visibleTimeStart={this.props.visibleTimeStart || defaultTimeStart}
+                    visibleTimeEnd={this.props.visibleTimeEnd || defaultTimeEnd}
+                    onTimeChange={this._handleTimeChange}
+                    canChangeGroup={false}
+                    stackItems={true}
+                    dragSnap={day}
+                    minZoom={week}
+                    canResize={"both"}
+                    minResizeWidth={50}
+                    onItemResize={this._onItemResize}
+                    onItemMove={this._onItemMove}
+                    moveResizeValidator={this._validateResize}
+                    selecte={[this.props.selectedItemId]}
+                    onItemSelect={itemId => this.props.onSetSelectedItemId(itemId)}
+                    onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
+                    itemRenderer={({ item, itemContext, getItemProps }) => {
+                        return (
+                            <div {...getItemProps(item.itemProps)}>
                                 <div
                                     style={{
+                                        maxHeight: `${itemContext.dimensions.height}`,
                                         display: "flex",
-                                        justifyContent: "flex-end"
+                                        justifyContent: "space-between",
+                                        overflow: "hidden",
+                                        marginRight: "5px",
+                                        alignItems: "baseline",
+                                        whiteSpace: "nowrap"
                                     }}
                                 >
-                                    <InfoIcon
-                                        id={item.id}
-                                        onClick={() => this.props.onToggleSetDatesDialogHidden(false)}
-                                    />
-                                    <ProgressDetails
-                                        completed={item.itemProps.completed}
-                                        total={item.itemProps.total}
-                                        onClick={() => {}}
-                                    />
+                                    {itemContext.title}
                                     <div
-                                        className="bowtie-icon bowtie-navigate-forward-circle"
-                                        style={forwardCircleStyle}
-                                        onClick={() => this.navigateToEpicRoadmap(item)}
+                                        style={{
+                                            display: "flex",
+                                            justifyContent: "flex-end"
+                                        }}
                                     >
-                                        &nbsp;
+                                        <InfoIcon
+                                            id={item.id}
+                                            onClick={() => this.props.onToggleSetDatesDialogHidden(false)}
+                                        />
+                                        <ProgressDetails
+                                            completed={item.itemProps.completed}
+                                            total={item.itemProps.total}
+                                            onClick={() => {}}
+                                        />
+                                        <div
+                                            className="bowtie-icon bowtie-navigate-forward-circle"
+                                            style={forwardCircleStyle}
+                                            onClick={() => this.navigateToEpicRoadmap(item)}
+                                        >
+                                            &nbsp;
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                    );
-                }}
-            />
+                        );
+                    }}
+                />
+            </div>
         );
     }
 

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -104,9 +104,14 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
                             </div>
                         );
                     }}
+                    groupRenderer={group => this._renderGroup(group.group)}
                 />
             </div>
         );
+    }
+
+    private _renderGroup(group: ITimelineGroup) {
+        return <div className="plan-timeline-group">{group.title}</div>;
     }
 
     // Update the visibleTimeStart and visibleTimeEnd when user scroll or zoom the timeline.

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -67,11 +67,8 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
                 </div>
             );
         } else {
-            return (
-                <div className="plan-timeline-container">
-                    <div>Add an item...</div>
-                </div>
-            );
+            // TODO: Zero data
+            return <div className="plan-timeline-container" />;
         }
     }
 

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -59,6 +59,7 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
                     onItemMove={this._onItemMove}
                     moveResizeValidator={this._validateResize}
                     selected={[this.props.selectedItemId]}
+                    lineHeight={50}
                     onItemSelect={itemId => this.props.onSetSelectedItemId(itemId)}
                     onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
                     itemRenderer={({ item, itemContext, getItemProps }) => {

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -37,10 +37,6 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
     public render(): JSX.Element {
         const [defaultTimeStart, defaultTimeEnd] = this._getDefaultTimes(this.props.items);
 
-        const forwardCircleStyle = {
-            padding: "0px 0px 0px 10px"
-        };
-
         return (
             <div className="plan-timeline-container">
                 <Timeline
@@ -62,51 +58,9 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
                     lineHeight={50}
                     onItemSelect={itemId => this.props.onSetSelectedItemId(itemId)}
                     onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
-                    itemRenderer={({ item, itemContext, getItemProps }) => {
-                        return (
-                            <div
-                                {...getItemProps({
-                                    className: "plan-timeline-item",
-                                    style: {
-                                        background: "white",
-                                        color: "black",
-                                        border: "none"
-                                    }
-                                })}
-                            >
-                                <div
-                                    style={{
-                                        maxHeight: `${itemContext.dimensions.height}`
-                                    }}
-                                >
-                                    {itemContext.title}
-                                    <div
-                                        style={{
-                                            display: "flex",
-                                            justifyContent: "flex-end"
-                                        }}
-                                    >
-                                        <InfoIcon
-                                            id={item.id}
-                                            onClick={() => this.props.onToggleSetDatesDialogHidden(false)}
-                                        />
-                                        <ProgressDetails
-                                            completed={item.itemProps.completed}
-                                            total={item.itemProps.total}
-                                            onClick={() => {}}
-                                        />
-                                        <div
-                                            className="bowtie-icon bowtie-navigate-forward-circle"
-                                            style={forwardCircleStyle}
-                                            onClick={() => this.navigateToEpicRoadmap(item)}
-                                        >
-                                            &nbsp;
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        );
-                    }}
+                    itemRenderer={({ item, itemContext, getItemProps }) =>
+                        this._renderItem(item, itemContext, getItemProps)
+                    }
                     groupRenderer={group => this._renderGroup(group.group)}
                 />
             </div>
@@ -116,6 +70,62 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
     private _renderGroup(group: ITimelineGroup) {
         return <div className="plan-timeline-group">{group.title}</div>;
     }
+
+    private _renderItem = (item, itemContext, getItemProps) => {
+        const forwardCircleStyle = {
+            padding: "0px 0px 0px 10px"
+        };
+
+        let borderStyle = {};
+        if (itemContext.selected) {
+            borderStyle = {
+                borderWidth: "1px",
+                borderStyle: "solid",
+                borderColor: "#106ebe"
+            };
+        } else {
+            borderStyle = {
+                border: "none"
+            };
+        }
+        return (
+            <div
+                {...getItemProps({
+                    className: "plan-timeline-item",
+                    style: {
+                        background: "white",
+                        color: "black",
+                        ...borderStyle,
+                        borderRadius: "4px"
+                    }
+                })}
+            >
+                <div className="details">
+                    <div className="title">{itemContext.title}</div>
+                    <div
+                        style={{
+                            display: "flex",
+                            justifyContent: "flex-end"
+                        }}
+                    >
+                        <InfoIcon id={item.id} onClick={() => this.props.onToggleSetDatesDialogHidden(false)} />
+                        <ProgressDetails
+                            completed={item.itemProps.completed}
+                            total={item.itemProps.total}
+                            onClick={() => {}}
+                        />
+                        <div
+                            className="bowtie-icon bowtie-navigate-forward-circle"
+                            style={forwardCircleStyle}
+                            onClick={() => this.navigateToEpicRoadmap(item)}
+                        >
+                            &nbsp;
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    };
 
     // Update the visibleTimeStart and visibleTimeEnd when user scroll or zoom the timeline.
     private _handleTimeChange = (visibleTimeStart, visibleTimeEnd, updateScrollCanvas): void => {

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -35,36 +35,44 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
     }
 
     public render(): JSX.Element {
-        const [defaultTimeStart, defaultTimeEnd] = this._getDefaultTimes(this.props.items);
+        if (this.props.items.length > 0) {
+            const [defaultTimeStart, defaultTimeEnd] = this._getDefaultTimes(this.props.items);
 
-        return (
-            <div className="plan-timeline-container">
-                <Timeline
-                    groups={this.props.groups}
-                    items={this.props.items}
-                    visibleTimeStart={this.props.visibleTimeStart || defaultTimeStart}
-                    visibleTimeEnd={this.props.visibleTimeEnd || defaultTimeEnd}
-                    onTimeChange={this._handleTimeChange}
-                    canChangeGroup={false}
-                    stackItems={true}
-                    dragSnap={day}
-                    minZoom={week}
-                    canResize={"both"}
-                    minResizeWidth={50}
-                    onItemResize={this._onItemResize}
-                    onItemMove={this._onItemMove}
-                    moveResizeValidator={this._validateResize}
-                    selected={[this.props.selectedItemId]}
-                    lineHeight={50}
-                    onItemSelect={itemId => this.props.onSetSelectedItemId(itemId)}
-                    onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
-                    itemRenderer={({ item, itemContext, getItemProps }) =>
-                        this._renderItem(item, itemContext, getItemProps)
-                    }
-                    groupRenderer={group => this._renderGroup(group.group)}
-                />
-            </div>
-        );
+            return (
+                <div className="plan-timeline-container">
+                    <Timeline
+                        groups={this.props.groups}
+                        items={this.props.items}
+                        visibleTimeStart={this.props.visibleTimeStart || defaultTimeStart}
+                        visibleTimeEnd={this.props.visibleTimeEnd || defaultTimeEnd}
+                        onTimeChange={this._handleTimeChange}
+                        canChangeGroup={false}
+                        stackItems={true}
+                        dragSnap={day}
+                        minZoom={week}
+                        canResize={"both"}
+                        minResizeWidth={50}
+                        onItemResize={this._onItemResize}
+                        onItemMove={this._onItemMove}
+                        moveResizeValidator={this._validateResize}
+                        selected={[this.props.selectedItemId]}
+                        lineHeight={50}
+                        onItemSelect={itemId => this.props.onSetSelectedItemId(itemId)}
+                        onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
+                        itemRenderer={({ item, itemContext, getItemProps }) =>
+                            this._renderItem(item, itemContext, getItemProps)
+                        }
+                        groupRenderer={group => this._renderGroup(group.group)}
+                    />
+                </div>
+            );
+        } else {
+            return (
+                <div className="plan-timeline-container">
+                    <div>Add an item...</div>
+                </div>
+            );
+        }
     }
 
     private _renderGroup(group: ITimelineGroup) {

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -58,7 +58,7 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
                     onItemResize={this._onItemResize}
                     onItemMove={this._onItemMove}
                     moveResizeValidator={this._validateResize}
-                    selecte={[this.props.selectedItemId]}
+                    selected={[this.props.selectedItemId]}
                     onItemSelect={itemId => this.props.onSetSelectedItemId(itemId)}
                     onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
                     itemRenderer={({ item, itemContext, getItemProps }) => {

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -64,16 +64,19 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
                     onCanvasClick={() => this.props.onSetSelectedItemId(undefined)}
                     itemRenderer={({ item, itemContext, getItemProps }) => {
                         return (
-                            <div {...getItemProps(item.itemProps)}>
+                            <div
+                                {...getItemProps({
+                                    className: "plan-timeline-item",
+                                    style: {
+                                        background: "white",
+                                        color: "black",
+                                        border: "none"
+                                    }
+                                })}
+                            >
                                 <div
                                     style={{
-                                        maxHeight: `${itemContext.dimensions.height}`,
-                                        display: "flex",
-                                        justifyContent: "space-between",
-                                        overflow: "hidden",
-                                        marginRight: "5px",
-                                        alignItems: "baseline",
-                                        whiteSpace: "nowrap"
+                                        maxHeight: `${itemContext.dimensions.height}`
                                     }}
                                 >
                                     {itemContext.title}

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -108,14 +108,18 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
                             justifyContent: "flex-end"
                         }}
                     >
-                        <InfoIcon id={item.id} onClick={() => this.props.onToggleSetDatesDialogHidden(false)} />
+                        <InfoIcon
+                            className="show-on-hover"
+                            id={item.id}
+                            onClick={() => this.props.onToggleSetDatesDialogHidden(false)}
+                        />
                         <ProgressDetails
                             completed={item.itemProps.completed}
                             total={item.itemProps.total}
                             onClick={() => {}}
                         />
                         <div
-                            className="bowtie-icon bowtie-navigate-forward-circle"
+                            className="bowtie-icon bowtie-navigate-forward-circle show-on-hover to-epic-roadmap"
                             style={forwardCircleStyle}
                             onClick={() => this.navigateToEpicRoadmap(item)}
                         >


### PR DESCRIPTION
The styling is closer to what design had in mind. At the very least it looks more azure devops-y. I moved info and redirect to epic roadmap buttons to after the progress bar. They only render when the item is hovered over.

In one of the style files you'll see lots of commented out lines. Reason for that is I edited the default styles of the timeline rather than using their extremely confusing custom rendering functions. It works for what we want now and we may have to switch to a different component to support rendering more detailed items anyway.

![image](https://user-images.githubusercontent.com/30058280/60929654-10e0a600-a267-11e9-88e4-4aee8051d8a3.png)
