### PR TITLE
Round dates

### DIFF
--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.scss
@@ -2,9 +2,7 @@
 @import "node_modules/azure-devops-ui/Core/core.scss";
 
 .plan-timeline-container {
-    margin-top: $spacing-16;
     height: 100%;
-
     background-color: $neutral-2;
 }
 
@@ -15,6 +13,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    white-space: normal;
+    text-align: center;
 }
 
 .plan-timeline-item {

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -20,6 +20,7 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 const epicToUpdate = draft.epics.find(epic => epic.id === epicId);
 
                 epicToUpdate.startDate = startDate.toDate();
+                epicToUpdate.startDate.setHours(0, 0, 0, 0);
 
                 break;
             }
@@ -29,6 +30,7 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 const epicToUpdate = draft.epics.find(epic => epic.id === epicId);
 
                 epicToUpdate.endDate = endDate.toDate();
+                epicToUpdate.endDate.setHours(0, 0, 0, 0);
 
                 break;
             }
@@ -40,7 +42,9 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 const epicDuration = epicToUpdate.endDate.getTime() - epicToUpdate.startDate.getTime();
 
                 epicToUpdate.startDate = startDate.toDate();
+                epicToUpdate.startDate.setHours(0, 0, 0, 0);
                 epicToUpdate.endDate = startDate.add(epicDuration, "milliseconds").toDate();
+                epicToUpdate.endDate.setHours(0, 0, 0, 0);
 
                 break;
             }

--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -169,7 +169,9 @@ function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActi
     queryResult.items.items.map(item => {
         if (!item.StartDate || !item.TargetDate) {
             now = new Date();
+            now.setHours(0, 0, 0, 0);
             oneMonthFromNow = new Date();
+            oneMonthFromNow.setHours(0, 0, 0, 0);
             oneMonthFromNow.setDate(now.getDate() + 30);
             epicsWithoutDates.push(item.WorkItemId);
             item.StartDate = now;


### PR DESCRIPTION
When we're adding an item to the timeline that doesn't have dates set it was using the current time to the minute. We're rounding that down to just the day since epics don't need time.

Fixed an issue where if the items were smaller than 2 months the timeline wouldn't scale when it opens to fit them. Also moved this default date calculation to only happen on first render. The dates still get updated when adding items.