### PR TITLE
Assign default sates to Epics when loading the portfolio.

### DIFF
--- a/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
@@ -1,0 +1,69 @@
+import {
+    PortfolioPlanningFullContentQueryResult
+} from "../../Models/PortfolioPlanningQueryModels";
+import { JsonPatchDocument } from "VSS/WebApi/Contracts";
+import { IEpic } from "../../Contracts";
+import { WorkItemTrackingHttpClient } from "TFS/WorkItemTracking/RestClient";
+import * as VSS_Service from "VSS/Service";
+import { effects, SagaIterator } from "redux-saga";
+import { getEpicById } from "../Selectors/EpicTimelineSelectors";
+
+export function* AssignDefaultDates(queryResult: PortfolioPlanningFullContentQueryResult) {
+
+    let epicsWithoutDates: number[] = [];
+    let now, oneMonthFromNow;
+
+    queryResult.items.items.map(item => {
+        if (!item.StartDate || !item.TargetDate) {
+            now = new Date();
+            now.setHours(0, 0, 0, 0);
+            oneMonthFromNow = new Date();
+            oneMonthFromNow.setHours(0, 0, 0, 0);
+            oneMonthFromNow.setDate(now.getDate() + 30);
+            epicsWithoutDates.push(item.WorkItemId);
+            item.StartDate = now;
+            item.TargetDate = oneMonthFromNow;
+        }
+    });
+
+    yield effects.all(epicsWithoutDates.map(entry => effects.call(saveDatesToServer, entry, now, oneMonthFromNow)));
+}
+
+/*
+This method is called from two places:
+1. setting dates for a selected epic from UI
+2. set default dates for newly added epic.
+In second case, epic is not saved into state yet.
+*/
+function* saveDatesToServer(epicId: number, defaultStartDate?: Date, defaultEndDate?: Date): SagaIterator {
+    const epic: IEpic = yield effects.select(getEpicById, epicId);
+    let startDate: Date = defaultStartDate;
+    let endDate: Date = defaultEndDate;
+
+    if (epic && epic.startDate && epic.endDate) {
+        startDate = epic.startDate;
+        endDate = epic.endDate;
+    }
+
+    const doc: JsonPatchDocument = [
+        {
+            op: "add",
+            path: "/fields/Microsoft.VSTS.Scheduling.StartDate",
+            value: startDate
+        },
+        {
+            op: "add",
+            path: "/fields/Microsoft.VSTS.Scheduling.TargetDate",
+            value: endDate
+        }
+    ];
+
+    const witHttpClient: WorkItemTrackingHttpClient = yield effects.call(
+        [VSS_Service, VSS_Service.getClient],
+        WorkItemTrackingHttpClient
+    );
+
+    yield effects.call([witHttpClient, witHttpClient.updateWorkItem], doc, epicId);
+
+    // TODO: Error experience
+}

--- a/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
@@ -8,7 +8,7 @@ import * as VSS_Service from "VSS/Service";
 import { effects, SagaIterator } from "redux-saga";
 import { getEpicById } from "../Selectors/EpicTimelineSelectors";
 
-export function* SetEpicDefaultDates(queryResult: PortfolioPlanningFullContentQueryResult) {
+export function* SetDefaultDatesForEpics(queryResult: PortfolioPlanningFullContentQueryResult) {
 
     let epicsWithoutDates: number[] = [];
     let now, oneMonthFromNow;
@@ -26,6 +26,7 @@ export function* SetEpicDefaultDates(queryResult: PortfolioPlanningFullContentQu
         }
     });
 
+    // Add error handling.
     yield effects.all(epicsWithoutDates.map(epic => effects.call(saveDatesToServer, epic, now, oneMonthFromNow)));
 }
 

--- a/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
@@ -36,7 +36,7 @@ This method is called from two places:
 2. set default dates for newly added epic.
 In second case, epic is not saved into state yet.
 */
-function* saveDatesToServer(epicId: number, defaultStartDate?: Date, defaultEndDate?: Date): SagaIterator {
+export function* saveDatesToServer(epicId: number, defaultStartDate?: Date, defaultEndDate?: Date): SagaIterator {
     const epic: IEpic = yield effects.select(getEpicById, epicId);
     let startDate: Date = defaultStartDate;
     let endDate: Date = defaultEndDate;

--- a/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
@@ -8,7 +8,7 @@ import * as VSS_Service from "VSS/Service";
 import { effects, SagaIterator } from "redux-saga";
 import { getEpicById } from "../Selectors/EpicTimelineSelectors";
 
-export function* AssignDefaultDates(queryResult: PortfolioPlanningFullContentQueryResult) {
+export function* SetEpicDefaultDates(queryResult: PortfolioPlanningFullContentQueryResult) {
 
     let epicsWithoutDates: number[] = [];
     let now, oneMonthFromNow;
@@ -26,7 +26,7 @@ export function* AssignDefaultDates(queryResult: PortfolioPlanningFullContentQue
         }
     });
 
-    yield effects.all(epicsWithoutDates.map(entry => effects.call(saveDatesToServer, entry, now, oneMonthFromNow)));
+    yield effects.all(epicsWithoutDates.map(epic => effects.call(saveDatesToServer, epic, now, oneMonthFromNow)));
 }
 
 /*

--- a/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
@@ -26,7 +26,7 @@ export function* SetDefaultDatesForEpics(queryResult: PortfolioPlanningFullConte
         }
     });
 
-    // Add error handling.
+    // TODO: Add error handling.
     yield effects.all(epicsWithoutDates.map(epic => effects.call(saveDatesToServer, epic, now, oneMonthFromNow)));
 }
 

--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -16,6 +16,7 @@ import { PortfolioPlanningDataService } from "../../Common/Services/PortfolioPla
 import { PlanDirectoryActionTypes, PlanDirectoryActions } from "../Actions/PlanDirectoryActions";
 import { LoadPortfolio } from "./LoadPortfolio";
 import { ActionsOfType } from "../Helpers";
+import { AssignDefaultDates } from "./DefaultDateUtil";
 
 export function* epicTimelineSaga(): SagaIterator {
     yield takeEvery(EpicTimelineActionTypes.UpdateStartDate, onUpdateStartDate);
@@ -163,23 +164,7 @@ function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActi
         portfolioQueryInput
     );
 
-    let epicsWithoutDates: number[] = [];
-    let now, oneMonthFromNow;
-
-    queryResult.items.items.map(item => {
-        if (!item.StartDate || !item.TargetDate) {
-            now = new Date();
-            oneMonthFromNow = new Date();
-            oneMonthFromNow.setDate(now.getDate() + 30);
-            epicsWithoutDates.push(item.WorkItemId);
-            item.StartDate = now;
-            item.TargetDate = oneMonthFromNow;
-        }
-    });
-
-    for (let index = 0; index < epicsWithoutDates.length; index++) {
-        yield effects.call(saveDatesToServer, epicsWithoutDates[index], now, oneMonthFromNow);
-    }
+    yield effects.call(AssignDefaultDates, queryResult);
 
     //  Add new epics selected by customer to existing ones in the plan.
     queryResult.mergeStrategy = MergeType.Add;

--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -3,9 +3,6 @@ import { SagaIterator, effects } from "redux-saga";
 import { EpicTimelineActionTypes, EpicTimelineActions } from "../Actions/EpicTimelineActions";
 import { getEpicById, getProjectConfigurationById } from "../Selectors/EpicTimelineSelectors";
 import { IEpic, IProjectConfiguration } from "../../Contracts";
-import * as VSS_Service from "VSS/Service";
-import { WorkItemTrackingHttpClient } from "TFS/WorkItemTracking/RestClient";
-import { JsonPatchDocument } from "VSS/WebApi/Contracts";
 import {
     PortfolioPlanningQueryInput,
     PortfolioPlanningFullContentQueryResult,
@@ -16,7 +13,7 @@ import { PortfolioPlanningDataService } from "../../Common/Services/PortfolioPla
 import { PlanDirectoryActionTypes, PlanDirectoryActions } from "../Actions/PlanDirectoryActions";
 import { LoadPortfolio } from "./LoadPortfolio";
 import { ActionsOfType } from "../Helpers";
-import { SetDefaultDatesForEpics } from "./DefaultDateUtil";
+import { SetDefaultDatesForEpics, saveDatesToServer } from "./DefaultDateUtil";
 
 export function* epicTimelineSaga(): SagaIterator {
     yield takeEvery(EpicTimelineActionTypes.UpdateStartDate, onUpdateStartDate);
@@ -45,46 +42,6 @@ function* onShiftEpic(action: ActionsOfType<EpicTimelineActions, EpicTimelineAct
     const epicId = action.payload.itemId;
     yield effects.call(saveDatesToServer, epicId);
 }
-
-/*
-This method is called from two places:
-1. setting dates for a selected epic from UI
-2. set default dates for newly added epic.
-In second case, epic is not saved into state yet.
-*/
-function* saveDatesToServer(epicId: number, defaultStartDate?: Date, defaultEndDate?: Date): SagaIterator {
-    const epic: IEpic = yield effects.select(getEpicById, epicId);
-    let startDate: Date = defaultStartDate;
-    let endDate: Date = defaultEndDate;
-
-    if (epic && epic.startDate && epic.endDate) {
-        startDate = epic.startDate;
-        endDate = epic.endDate;
-    }
-
-    const doc: JsonPatchDocument = [
-        {
-            op: "add",
-            path: "/fields/Microsoft.VSTS.Scheduling.StartDate",
-            value: startDate
-        },
-        {
-            op: "add",
-            path: "/fields/Microsoft.VSTS.Scheduling.TargetDate",
-            value: endDate
-        }
-    ];
-
-    const witHttpClient: WorkItemTrackingHttpClient = yield effects.call(
-        [VSS_Service, VSS_Service.getClient],
-        WorkItemTrackingHttpClient
-    );
-
-    yield effects.call([witHttpClient, witHttpClient.updateWorkItem], doc, epicId);
-
-    // TODO: Error experience
-}
-
 function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActionTypes.AddItems>): SagaIterator {
     const {
         planId,

--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -16,7 +16,7 @@ import { PortfolioPlanningDataService } from "../../Common/Services/PortfolioPla
 import { PlanDirectoryActionTypes, PlanDirectoryActions } from "../Actions/PlanDirectoryActions";
 import { LoadPortfolio } from "./LoadPortfolio";
 import { ActionsOfType } from "../Helpers";
-import { SetEpicDefaultDates } from "./DefaultDateUtil";
+import { SetDefaultDatesForEpics } from "./DefaultDateUtil";
 
 export function* epicTimelineSaga(): SagaIterator {
     yield takeEvery(EpicTimelineActionTypes.UpdateStartDate, onUpdateStartDate);
@@ -164,7 +164,7 @@ function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActi
         portfolioQueryInput
     );
 
-    yield effects.call(SetEpicDefaultDates, queryResult);
+    yield effects.call(SetDefaultDatesForEpics, queryResult);
 
     //  Add new epics selected by customer to existing ones in the plan.
     queryResult.mergeStrategy = MergeType.Add;

--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -16,7 +16,7 @@ import { PortfolioPlanningDataService } from "../../Common/Services/PortfolioPla
 import { PlanDirectoryActionTypes, PlanDirectoryActions } from "../Actions/PlanDirectoryActions";
 import { LoadPortfolio } from "./LoadPortfolio";
 import { ActionsOfType } from "../Helpers";
-import { AssignDefaultDates } from "./DefaultDateUtil";
+import { SetEpicDefaultDates } from "./DefaultDateUtil";
 
 export function* epicTimelineSaga(): SagaIterator {
     yield takeEvery(EpicTimelineActionTypes.UpdateStartDate, onUpdateStartDate);
@@ -164,7 +164,7 @@ function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActi
         portfolioQueryInput
     );
 
-    yield effects.call(AssignDefaultDates, queryResult);
+    yield effects.call(SetEpicDefaultDates, queryResult);
 
     //  Add new epics selected by customer to existing ones in the plan.
     queryResult.mergeStrategy = MergeType.Add;

--- a/src/PortfolioPlanning/Redux/Sagas/LoadPortfolio.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/LoadPortfolio.ts
@@ -7,6 +7,8 @@ import {
     MergeType
 } from "../../Models/PortfolioPlanningQueryModels";
 import { EpicTimelineActions } from "../Actions/EpicTimelineActions";
+import { effects } from "redux-saga";
+import { AssignDefaultDates } from "./DefaultDateUtil";
 
 export function* LoadPortfolio(planId: string) {
     const portfolioService = PortfolioPlanningDataService.getInstance();
@@ -56,6 +58,8 @@ export function* LoadPortfolio(planId: string) {
         portfolioQueryInput
     );
 
+    yield effects.call(AssignDefaultDates, queryResult);
+    
     //  Replace all values when merging. We are loading the full state of the portfolio here.
     queryResult.mergeStrategy = MergeType.Replace;
 

--- a/src/PortfolioPlanning/Redux/Sagas/LoadPortfolio.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/LoadPortfolio.ts
@@ -8,7 +8,7 @@ import {
 } from "../../Models/PortfolioPlanningQueryModels";
 import { EpicTimelineActions } from "../Actions/EpicTimelineActions";
 import { effects } from "redux-saga";
-import { AssignDefaultDates } from "./DefaultDateUtil";
+import { SetEpicDefaultDates } from "./DefaultDateUtil";
 
 export function* LoadPortfolio(planId: string) {
     const portfolioService = PortfolioPlanningDataService.getInstance();
@@ -58,8 +58,8 @@ export function* LoadPortfolio(planId: string) {
         portfolioQueryInput
     );
 
-    yield effects.call(AssignDefaultDates, queryResult);
-    
+    yield effects.call(SetEpicDefaultDates, queryResult);
+
     //  Replace all values when merging. We are loading the full state of the portfolio here.
     queryResult.mergeStrategy = MergeType.Replace;
 

--- a/src/PortfolioPlanning/Redux/Sagas/LoadPortfolio.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/LoadPortfolio.ts
@@ -1,4 +1,5 @@
 import { put, call } from "redux-saga/effects";
+import { effects } from "redux-saga";
 import { PortfolioPlanningDataService } from "../../Common/Services/PortfolioPlanningDataService";
 import {
     PortfolioPlanningQueryInput,
@@ -7,8 +8,7 @@ import {
     MergeType
 } from "../../Models/PortfolioPlanningQueryModels";
 import { EpicTimelineActions } from "../Actions/EpicTimelineActions";
-import { effects } from "redux-saga";
-import { SetEpicDefaultDates } from "./DefaultDateUtil";
+import { SetDefaultDatesForEpics } from "./DefaultDateUtil";
 
 export function* LoadPortfolio(planId: string) {
     const portfolioService = PortfolioPlanningDataService.getInstance();
@@ -58,7 +58,7 @@ export function* LoadPortfolio(planId: string) {
         portfolioQueryInput
     );
 
-    yield effects.call(SetEpicDefaultDates, queryResult);
+    yield effects.call(SetDefaultDatesForEpics, queryResult);
 
     //  Replace all values when merging. We are loading the full state of the portfolio here.
     queryResult.mergeStrategy = MergeType.Replace;


### PR DESCRIPTION
Added a generator function to assign default dates to each epic that has an empty date. Now default dates are added at both times - while the portfolio is loaded and when adding a new epic. 