### PR TITLE
New plan experience

### DIFF
--- a/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
+++ b/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
@@ -377,6 +377,11 @@ export class PortfolioPlanningDataService {
         }
 
         const directory: PortfolioPlanningDirectory = doc;
+
+        for (const entry of directory.entries) {
+            entry.createdOn = new Date(entry.createdOn);
+        }
+
         return directory;
     }
 

--- a/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
@@ -13,6 +13,7 @@ import { EpicTimelineActions } from "../../Redux/Actions/EpicTimelineActions";
 import { LoadingStatus } from "../../Contracts";
 import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
 import { MessageCard, MessageCardSeverity } from "azure-devops-ui/MessageCard";
+import { ZeroDataActionType, ZeroData } from "azure-devops-ui/ZeroData";
 
 export interface IPlanDirectoryProps {}
 
@@ -64,22 +65,36 @@ export class PlanDirectory extends React.Component<IPlanDirectoryProps & IPlanDi
                 </MessageCard>
             );
 
-            const plans = this.props.plans.map(plan => (
-                <PlanCard
-                    planId={plan.id}
-                    name={plan.name}
-                    description={plan.description}
-                    teams={plan.teamNames}
-                    projects={plan.projectNames}
-                    owner={plan.owner}
-                    onClick={id => this.props.toggleSelectedPlanId(id)}
-                />
-            ));
+            let content =
+                this.props.plans.length > 0 ? (
+                    this.props.plans.map(plan => (
+                        <PlanCard
+                            planId={plan.id}
+                            name={plan.name}
+                            description={plan.description}
+                            teams={plan.teamNames}
+                            projects={plan.projectNames}
+                            owner={plan.owner}
+                            onClick={id => this.props.toggleSelectedPlanId(id)}
+                        />
+                    ))
+                ) : (
+                    // TODO: Add zero data images
+                    <ZeroData
+                        imagePath=""
+                        imageAltText=""
+                        primaryText="Get started with portfolio plans"
+                        secondaryText="Use the &quot;New Plan&quot; button to create a plan and add items to it"
+                        actionText="New plan"
+                        actionType={ZeroDataActionType.ctaButton}
+                        onActionClick={() => this.props.toggleNewPlanDialogVisible(true)}
+                    />
+                );
 
             return (
                 <div className="page-content plan-directory-page-content">
                     {this.props.exceptionMessage && exceptionMessageCard}
-                    <div className="plan-cards-container">{plans}</div>
+                    <div className="plan-cards-container">{content}</div>
                 </div>
             );
         }

--- a/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
+++ b/src/PortfolioPlanning/Components/Directory/PlanDirectory.tsx
@@ -67,17 +67,19 @@ export class PlanDirectory extends React.Component<IPlanDirectoryProps & IPlanDi
 
             let content =
                 this.props.plans.length > 0 ? (
-                    this.props.plans.map(plan => (
-                        <PlanCard
-                            planId={plan.id}
-                            name={plan.name}
-                            description={plan.description}
-                            teams={plan.teamNames}
-                            projects={plan.projectNames}
-                            owner={plan.owner}
-                            onClick={id => this.props.toggleSelectedPlanId(id)}
-                        />
-                    ))
+                    <div className="plan-cards-container">
+                        {this.props.plans.map(plan => (
+                            <PlanCard
+                                planId={plan.id}
+                                name={plan.name}
+                                description={plan.description}
+                                teams={plan.teamNames}
+                                projects={plan.projectNames}
+                                owner={plan.owner}
+                                onClick={id => this.props.toggleSelectedPlanId(id)}
+                            />
+                        ))}
+                    </div>
                 ) : (
                     // TODO: Add zero data images
                     <ZeroData
@@ -94,7 +96,7 @@ export class PlanDirectory extends React.Component<IPlanDirectoryProps & IPlanDi
             return (
                 <div className="page-content plan-directory-page-content">
                     {this.props.exceptionMessage && exceptionMessageCard}
-                    <div className="plan-cards-container">{content}</div>
+                    {content}
                 </div>
             );
         }

--- a/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
@@ -9,7 +9,8 @@ import {
     getProjectNames,
     getTeamNames,
     getSelectedItem,
-    getEpicIds
+    getEpicIds,
+    isNewPlan
 } from "../../Redux/Selectors/EpicTimelineSelectors";
 import { getSelectedPlanMetadata } from "../../Redux/Selectors/PlanDirectorySelectors";
 import { connect } from "react-redux";
@@ -35,6 +36,7 @@ interface IPlanPageMappedProps {
     planSettingsPanelOpen: boolean;
     exceptionMessage: string;
     planLoadingStatus: LoadingStatus;
+    isNewPlan: boolean;
 }
 
 export type IPlanPageProps = IPlanPageMappedProps & typeof Actions;
@@ -119,7 +121,7 @@ export default class PlanPage extends React.Component<IPlanPageProps, IPortfolio
     };
 
     private _renderAddItemPanel = (): JSX.Element => {
-        if (this.props.addItemPanelOpen) {
+        if (this.props.addItemPanelOpen || this.props.isNewPlan) {
             return (
                 <AddItemPanel
                     planId={this.props.plan.id}
@@ -203,7 +205,8 @@ function mapStateToProps(state: IPortfolioPlanningState): IPlanPageMappedProps {
         setDatesDialogHidden: state.epicTimelineState.setDatesDialogHidden,
         planSettingsPanelOpen: state.epicTimelineState.planSettingsPanelOpen,
         exceptionMessage: state.epicTimelineState.exceptionMessage,
-        planLoadingStatus: state.epicTimelineState.planLoadingStatus
+        planLoadingStatus: state.epicTimelineState.planLoadingStatus,
+        isNewPlan: isNewPlan(state)
     };
 }
 

--- a/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
@@ -9,8 +9,7 @@ import {
     getProjectNames,
     getTeamNames,
     getSelectedItem,
-    getEpicIds,
-    isNewPlan
+    getEpicIds
 } from "../../Redux/Selectors/EpicTimelineSelectors";
 import { getSelectedPlanMetadata } from "../../Redux/Selectors/PlanDirectorySelectors";
 import { connect } from "react-redux";
@@ -36,7 +35,7 @@ interface IPlanPageMappedProps {
     planSettingsPanelOpen: boolean;
     exceptionMessage: string;
     planLoadingStatus: LoadingStatus;
-    isNewPlan: boolean;
+    isNewPlanExperience: boolean;
 }
 
 export type IPlanPageProps = IPlanPageMappedProps & typeof Actions;
@@ -121,7 +120,7 @@ export default class PlanPage extends React.Component<IPlanPageProps, IPortfolio
     };
 
     private _renderAddItemPanel = (): JSX.Element => {
-        if (this.props.addItemPanelOpen || this.props.isNewPlan) {
+        if (this.props.addItemPanelOpen || this.props.isNewPlanExperience) {
             return (
                 <AddItemPanel
                     planId={this.props.plan.id}
@@ -201,12 +200,12 @@ function mapStateToProps(state: IPortfolioPlanningState): IPlanPageMappedProps {
         epicIds: getEpicIds(state.epicTimelineState),
         selectedItem: getSelectedItem(state.epicTimelineState),
         progressTrackingCriteria: state.epicTimelineState.progressTrackingCriteria,
-        addItemPanelOpen: state.epicTimelineState.addEpicDialogOpen,
+        addItemPanelOpen: state.epicTimelineState.addItemsPanelOpen,
         setDatesDialogHidden: state.epicTimelineState.setDatesDialogHidden,
         planSettingsPanelOpen: state.epicTimelineState.planSettingsPanelOpen,
         exceptionMessage: state.epicTimelineState.exceptionMessage,
         planLoadingStatus: state.epicTimelineState.planLoadingStatus,
-        isNewPlan: isNewPlan(state)
+        isNewPlanExperience: state.epicTimelineState.isNewPlanExperience
     };
 }
 

--- a/src/PortfolioPlanning/Components/Plan/PlanSummary.scss
+++ b/src/PortfolioPlanning/Components/Plan/PlanSummary.scss
@@ -4,9 +4,11 @@
 .plan-summary {
     display: flex;
     margin-left: $spacing-32;
+    width: 100%;
 
     .owner {
         display: flex;
+        flex-shrink: 0;
         align-items: center;
 
         .display-name {
@@ -19,7 +21,8 @@
 
     .summary-item {
         padding-right: $spacing-32;
-        max-width: 400px;
+        flex: 0 1 auto;
+        overflow: auto;
     }
 
     .projects-teams-label {
@@ -28,7 +31,7 @@
     }
     .projects-teams-content {
         @extend .title-s;
-        max-height: 48px;
+        white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
     }

--- a/src/PortfolioPlanning/Components/Plan/PlanSummary.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanSummary.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import "./PlanSummary.scss";
 import { IdentityRef } from "VSS/WebApi/Contracts";
 import { IdentityView } from "../../Common/Components/IdentityView";
+import { Tooltip } from "azure-devops-ui/TooltipEx";
 
 export interface IPlanSummaryProps {
     owner: IdentityRef;
@@ -19,13 +20,17 @@ export const PlanSummary = (props: IPlanSummaryProps) => {
             {projectNameList && (
                 <div className="summary-item">
                     <div className="projects-teams-label">Projects</div>
-                    <div className="projects-teams-content">{projectNameList}</div>
+                    <Tooltip overflowOnly={true}>
+                        <div className="projects-teams-content">{projectNameList}</div>
+                    </Tooltip>
                 </div>
             )}
             {teamNameList && (
                 <div className="summary-item">
                     <div className="projects-teams-label">Teams</div>
-                    <div className="projects-teams-content">{teamNameList}</div>
+                    <Tooltip overflowOnly={true}>
+                        <div className="projects-teams-content">{teamNameList}</div>
+                    </Tooltip>
                 </div>
             )}
         </div>

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -79,6 +79,7 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
                     imagePath=""
                     imageAltText=""
                     primaryText="This plan is empty"
+                    secondaryText="Use the &quot;+&quot; button to add items to this plan"
                     actionText="Add items"
                     actionType={ZeroDataActionType.ctaButton}
                     onActionClick={this.props.onZeroDataCtaClicked}

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -11,6 +11,7 @@ import { ProgressDetails } from "../../Common/Components/ProgressDetails";
 import { InfoIcon } from "../../Common/Components/InfoIcon";
 import { getSelectedPlanOwner } from "../../Redux/Selectors/PlanDirectorySelectors";
 import { IdentityRef } from "VSS/WebApi/Contracts";
+import { ZeroData, ZeroDataActionType } from "azure-devops-ui/ZeroData";
 
 const day = 60 * 60 * 24 * 1000;
 const week = day * 7;
@@ -72,8 +73,17 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
                 </div>
             );
         } else {
-            // TODO: Zero data
-            return <div className="plan-timeline-container" />;
+            return (
+                // TODO: Add zero data images
+                <ZeroData
+                    imagePath=""
+                    imageAltText=""
+                    primaryText="This plan is empty"
+                    actionText="Add items"
+                    actionType={ZeroDataActionType.ctaButton}
+                    onActionClick={this.props.onZeroDataCtaClicked}
+                />
+            );
         }
     }
 
@@ -237,7 +247,8 @@ const Actions = {
     onToggleSetDatesDialogHidden: EpicTimelineActions.toggleItemDetailsDialogHidden,
     onSetSelectedItemId: EpicTimelineActions.setSelectedItemId,
     onUpdateVisibleTimeStart: EpicTimelineActions.updateVisibleTimeStart,
-    onUpdateVisibleTimeEnd: EpicTimelineActions.updateVisibleTimeEnd
+    onUpdateVisibleTimeEnd: EpicTimelineActions.updateVisibleTimeEnd,
+    onZeroDataCtaClicked: EpicTimelineActions.openAddItemPanel
 };
 
 export const ConnectedPlanTimeline = connect(

--- a/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
+++ b/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
@@ -22,7 +22,8 @@ export const enum EpicTimelineActionTypes {
     ResetPlanState = "EpicTimeline/ResetPlanState",
     TogglePlanSettingsPanelOpen = "EpicTimeline/TogglePlanSettingsPanelOpen",
     UpdateVisibleTimeStart = "EpicTimeline/UpdateVisibleTimeStart",
-    UpdateVisibleTimeEnd = "EpicTimeline/UpdateVisibleTimeEnd"
+    UpdateVisibleTimeEnd = "EpicTimeline/UpdateVisibleTimeEnd",
+    ToggleIsNewPlanExperience = "EpicTimeline/IsNewPlanExperience"
 }
 
 export const EpicTimelineActions = {
@@ -67,7 +68,9 @@ export const EpicTimelineActions = {
     updateVisibleTimeEnd: (visibleTimeEnd: number) =>
         createAction(EpicTimelineActionTypes.UpdateVisibleTimeEnd, {
             visibleTimeEnd
-        })
+        }),
+    toggleIsNewPlanExperience: (isNewPlanExperience: boolean) =>
+        createAction(EpicTimelineActionTypes.ToggleIsNewPlanExperience, { isNewPlanExperience })
 };
 
 export type EpicTimelineActions = ActionsUnion<typeof EpicTimelineActions>;

--- a/src/PortfolioPlanning/Redux/Contracts.ts
+++ b/src/PortfolioPlanning/Redux/Contracts.ts
@@ -14,13 +14,14 @@ export interface IEpicTimelineState {
     teams: { [teamId: string]: ITeam };
     epics: IEpic[];
     message: string;
-    addEpicDialogOpen: boolean;
+    addItemsPanelOpen: boolean;
     setDatesDialogHidden: boolean;
     planSettingsPanelOpen: boolean;
     selectedItemId: number;
     progressTrackingCriteria: ProgressTrackingCriteria;
     visibleTimeStart: number;
     visibleTimeEnd: number;
+    isNewPlanExperience: boolean;
 }
 
 export interface IPlanDirectoryState {

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -71,11 +71,12 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 return handlePortfolioItemsReceived(draft, action as PortfolioItemsReceivedAction);
 
             case EpicTimelineActionTypes.OpenAddItemPanel: {
-                draft.addEpicDialogOpen = true;
+                draft.addItemsPanelOpen = true;
                 break;
             }
             case EpicTimelineActionTypes.CloseAddItemPanel: {
-                draft.addEpicDialogOpen = false;
+                draft.addItemsPanelOpen = false;
+                draft.isNewPlanExperience = false;
                 break;
             }
             case EpicTimelineActionTypes.PortfolioItemDeleted: {
@@ -96,13 +97,14 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 draft.planLoadingStatus = LoadingStatus.NotLoaded;
                 draft.selectedItemId = undefined;
                 draft.setDatesDialogHidden = true;
-                draft.addEpicDialogOpen = false;
+                draft.addItemsPanelOpen = false;
                 draft.planSettingsPanelOpen = false;
                 draft.visibleTimeStart = undefined;
                 draft.visibleTimeEnd = undefined;
                 draft.epics = [];
                 draft.projects = [];
                 draft.teams = {};
+                draft.isNewPlanExperience = false;
 
                 break;
             }
@@ -121,6 +123,10 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 draft.visibleTimeEnd = action.payload.visibleTimeEnd;
                 break;
             }
+            case EpicTimelineActionTypes.ToggleIsNewPlanExperience: {
+                draft.isNewPlanExperience = action.payload.isNewPlanExperience;
+                break;
+            }
         }
     });
 }
@@ -134,13 +140,14 @@ export function getDefaultState(): IEpicTimelineState {
         teams: {},
         epics: [],
         message: "Initial message",
-        addEpicDialogOpen: false,
+        addItemsPanelOpen: false,
         setDatesDialogHidden: true,
         planSettingsPanelOpen: false,
         selectedItemId: null,
         progressTrackingCriteria: ProgressTrackingCriteria.CompletedCount,
         visibleTimeStart: null,
-        visibleTimeEnd: null
+        visibleTimeEnd: null,
+        isNewPlanExperience: false
     };
 }
 

--- a/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
@@ -7,7 +7,7 @@ import {
     PortfolioPlanningMetadata,
     PortfolioPlanning
 } from "../../Models/PortfolioPlanningQueryModels";
-import { EpicTimelineActionTypes } from "../Actions/EpicTimelineActions";
+import { EpicTimelineActionTypes, EpicTimelineActions } from "../Actions/EpicTimelineActions";
 import { getSelectedPlanId } from "../Selectors/PlanDirectorySelectors";
 import { getCurrentUser } from "../../Common/Utilities/Identity";
 import { getProjectNames, getTeamNames, getExceptionMessage } from "../Selectors/EpicTimelineSelectors";
@@ -45,6 +45,7 @@ function* createPlan(action: ActionsOfType<PlanDirectoryActions, PlanDirectoryAc
         );
         yield effects.put(PlanDirectoryActions.createPlanSucceeded(newPlan));
         yield effects.put(PlanDirectoryActions.toggleSelectedPlanId(newPlan.id));
+        yield effects.put(EpicTimelineActions.toggleIsNewPlanExperience(true));
     } catch (exception) {
         yield effects.put(PlanDirectoryActions.createPlanFailed(exception));
     }

--- a/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
+++ b/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
@@ -8,6 +8,7 @@ import {
     IProjectConfiguration
 } from "../../Contracts";
 import moment = require("moment");
+import { getSelectedPlanMetadata } from "./PlanDirectorySelectors";
 
 export function getProjects(state: IEpicTimelineState): IProject[] {
     return state.projects;
@@ -117,4 +118,18 @@ export function getProgressTrackingCriteria(state: IEpicTimelineState): Progress
 
 export function getExceptionMessage(state: IPortfolioPlanningState): string {
     return state.epicTimelineState.exceptionMessage;
+}
+
+export function isNewPlan(state: IPortfolioPlanningState): boolean {
+    const selectedPlan = getSelectedPlanMetadata(state);
+
+    if (
+        selectedPlan &&
+        Date.now() - selectedPlan.createdOn.getTime() < 5 * 1000 &&
+        selectedPlan.projectNames.length == 0
+    ) {
+        return true;
+    } else {
+        return false;
+    }
 }

--- a/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
+++ b/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
@@ -8,7 +8,6 @@ import {
     IProjectConfiguration
 } from "../../Contracts";
 import moment = require("moment");
-import { getSelectedPlanMetadata } from "./PlanDirectorySelectors";
 
 export function getProjects(state: IEpicTimelineState): IProject[] {
     return state.projects;
@@ -109,7 +108,7 @@ export function getSetDatesDialogHidden(state: IEpicTimelineState): boolean {
 }
 
 export function getAddEpicPanelOpen(state: IEpicTimelineState): boolean {
-    return state.addEpicDialogOpen;
+    return state.addItemsPanelOpen;
 }
 
 export function getProgressTrackingCriteria(state: IEpicTimelineState): ProgressTrackingCriteria {
@@ -118,18 +117,4 @@ export function getProgressTrackingCriteria(state: IEpicTimelineState): Progress
 
 export function getExceptionMessage(state: IPortfolioPlanningState): string {
     return state.epicTimelineState.exceptionMessage;
-}
-
-export function isNewPlan(state: IPortfolioPlanningState): boolean {
-    const selectedPlan = getSelectedPlanMetadata(state);
-
-    if (
-        selectedPlan &&
-        Date.now() - selectedPlan.createdOn.getTime() < 5 * 1000 &&
-        selectedPlan.projectNames.length == 0
-    ) {
-        return true;
-    } else {
-        return false;
-    }
 }


### PR DESCRIPTION
- Opens the Add items panel when a new plan is created
- Zero data on both the directory and plan page with CTA buttons
- Fixed some styling with the projects and teams lists above the timeline
